### PR TITLE
fix: use origin tracking branches for preparing review branches

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,4 +1,4 @@
-use crate::git::run_git_command;
+use crate::git::{resolve_remote_tracking_branch, run_git_command};
 use colored::Colorize;
 use std::ops::Not;
 use std::process::exit;
@@ -19,14 +19,26 @@ pub fn prepare_review_branch(
     stop_at: Option<&str>,
     verbose: bool,
 ) {
-    let review_branch = format!("review-{}-{}", to_branch, from_branch);
-    let origin_to = format!("origin/{}", to_branch);
-    let origin_from = format!("origin/{}", from_branch);
+    let review_branch = format!("review-{}-{}", to_branch, from_branch).replace("/", "_");
 
-    // Fetch both branches from origin
+    let resolved_to = resolve_remote_tracking_branch(to_branch, verbose);
+    let resolved_from = resolve_remote_tracking_branch(from_branch, verbose);
+
+    let tracking_to = resolved_to.tracking_ref;
+    let tracking_from = resolved_from.tracking_ref;
+
+    // Fetch the target branch
     run_git_command(
-        "fetch origin branches",
-        &["fetch", "origin", to_branch, from_branch],
+        &format!("fetch target branch from {}", resolved_to.remote),
+        &["fetch", &resolved_to.remote, &resolved_to.remote_branch],
+        false,
+        verbose,
+    );
+
+    // Fetch the source branch
+    run_git_command(
+        &format!("fetch source branch from {}", resolved_from.remote),
+        &["fetch", &resolved_from.remote, &resolved_from.remote_branch],
         false,
         verbose,
     );
@@ -34,7 +46,7 @@ pub fn prepare_review_branch(
     // Get merge-base
     let merge_base_output = run_git_command(
         "get merge base",
-        &["merge-base", &origin_to, &origin_from],
+        &["merge-base", &tracking_to, &tracking_from],
         false,
         verbose,
     );
@@ -42,10 +54,10 @@ pub fn prepare_review_branch(
         .trim()
         .to_string();
 
-    // Get valid commit range (merge_base..origin_from)
+    // Get valid commit range (merge_base..tracking_from)
     let valid_commits = run_git_command(
         "get valid commit range",
-        &["rev-list", &format!("{}..{}", merge_base, origin_from)],
+        &["rev-list", &format!("{}..{}", merge_base, tracking_from)],
         false,
         verbose,
     );
@@ -86,7 +98,7 @@ pub fn prepare_review_branch(
         if let Some(skip_hash) = skip_to {
             let skip_to_commits = run_git_command(
                 "get commits after skip_to",
-                &["rev-list", &format!("{}..{}", skip_hash, origin_from)],
+                &["rev-list", &format!("{}..{}", skip_hash, tracking_from)],
                 false,
                 verbose,
             );
@@ -182,11 +194,11 @@ pub fn prepare_review_branch(
             );
         }
 
-        // Use stop_at if specified, otherwise origin_from
-        stop_at.unwrap_or(&origin_from).to_string()
+        // Use stop_at if specified, otherwise tracking_from
+        stop_at.unwrap_or(&tracking_from).to_string()
     } else {
-        // Use stop_at if specified, otherwise origin_from
-        stop_at.unwrap_or(&origin_from).to_string()
+        // Use stop_at if specified, otherwise tracking_from
+        stop_at.unwrap_or(&tracking_from).to_string()
     };
 
     // Squash merge remaining changes
@@ -275,12 +287,13 @@ pub struct ReviewStatus {
 ///
 /// * `ReviewStatus` - The remaining diff statistics
 pub fn get_review_status(from_branch: &str, verbose: bool) -> ReviewStatus {
-    let origin_from = format!("origin/{}", from_branch);
+    let resolved_from = resolve_remote_tracking_branch(from_branch, verbose);
+    let tracking_from = resolved_from.tracking_ref;
 
     // Get diff stats summary (use HEAD..branch for direct comparison, not HEAD...branch)
     let stat_output = run_git_command(
         "get diff stats",
-        &["diff", "--stat", "HEAD", &origin_from],
+        &["diff", "--stat", "HEAD", &tracking_from],
         false,
         verbose,
     );
@@ -313,7 +326,7 @@ pub fn get_review_status(from_branch: &str, verbose: bool) -> ReviewStatus {
     // Get list of changed files
     let files_output = run_git_command(
         "get changed files",
-        &["diff", "--name-only", "HEAD", &origin_from],
+        &["diff", "--name-only", "HEAD", &tracking_from],
         false,
         verbose,
     );

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -20,29 +20,13 @@ pub fn prepare_review_branch(
     verbose: bool,
 ) {
     let review_branch = format!("review-{}-{}", to_branch, from_branch);
+    let origin_to = format!("origin/{}", to_branch);
+    let origin_from = format!("origin/{}", from_branch);
 
-    // Fetch and update both branches
+    // Fetch both branches from origin
     run_git_command(
-        &format!("switch to {} branch", from_branch),
-        &["switch", from_branch],
-        false,
-        verbose,
-    );
-    run_git_command(
-        &format!("pull {} branch", from_branch),
-        &["pull", "origin", from_branch],
-        false,
-        verbose,
-    );
-    run_git_command(
-        &format!("switch to {} branch", to_branch),
-        &["switch", to_branch],
-        false,
-        verbose,
-    );
-    run_git_command(
-        &format!("pull {} branch", to_branch),
-        &["pull", "origin", to_branch],
+        "fetch origin branches",
+        &["fetch", "origin", to_branch, from_branch],
         false,
         verbose,
     );
@@ -50,7 +34,7 @@ pub fn prepare_review_branch(
     // Get merge-base
     let merge_base_output = run_git_command(
         "get merge base",
-        &["merge-base", to_branch, from_branch],
+        &["merge-base", &origin_to, &origin_from],
         false,
         verbose,
     );
@@ -58,10 +42,10 @@ pub fn prepare_review_branch(
         .trim()
         .to_string();
 
-    // Get valid commit range (merge_base..from_branch)
+    // Get valid commit range (merge_base..origin_from)
     let valid_commits = run_git_command(
         "get valid commit range",
-        &["rev-list", &format!("{}..{}", merge_base, from_branch)],
+        &["rev-list", &format!("{}..{}", merge_base, origin_from)],
         false,
         verbose,
     );
@@ -102,7 +86,7 @@ pub fn prepare_review_branch(
         if let Some(skip_hash) = skip_to {
             let skip_to_commits = run_git_command(
                 "get commits after skip_to",
-                &["rev-list", &format!("{}..{}", skip_hash, from_branch)],
+                &["rev-list", &format!("{}..{}", skip_hash, origin_from)],
                 false,
                 verbose,
             );
@@ -180,6 +164,7 @@ pub fn prepare_review_branch(
                 &[
                     "merge",
                     "--squash",
+                    "--ff",
                     "--quiet",
                     "--no-stat",
                     "-X",
@@ -197,11 +182,11 @@ pub fn prepare_review_branch(
             );
         }
 
-        // Use stop_at if specified, otherwise from_branch
-        stop_at.unwrap_or(from_branch).to_string()
+        // Use stop_at if specified, otherwise origin_from
+        stop_at.unwrap_or(&origin_from).to_string()
     } else {
-        // Use stop_at if specified, otherwise from_branch
-        stop_at.unwrap_or(from_branch).to_string()
+        // Use stop_at if specified, otherwise origin_from
+        stop_at.unwrap_or(&origin_from).to_string()
     };
 
     // Squash merge remaining changes
@@ -210,6 +195,7 @@ pub fn prepare_review_branch(
         &[
             "merge",
             "--squash",
+            "--ff",
             "--quiet",
             "--no-stat",
             "-X",
@@ -289,10 +275,12 @@ pub struct ReviewStatus {
 ///
 /// * `ReviewStatus` - The remaining diff statistics
 pub fn get_review_status(from_branch: &str, verbose: bool) -> ReviewStatus {
+    let origin_from = format!("origin/{}", from_branch);
+
     // Get diff stats summary (use HEAD..branch for direct comparison, not HEAD...branch)
     let stat_output = run_git_command(
         "get diff stats",
-        &["diff", "--stat", "HEAD", from_branch],
+        &["diff", "--stat", "HEAD", &origin_from],
         false,
         verbose,
     );
@@ -325,7 +313,7 @@ pub fn get_review_status(from_branch: &str, verbose: bool) -> ReviewStatus {
     // Get list of changed files
     let files_output = run_git_command(
         "get changed files",
-        &["diff", "--name-only", "HEAD", from_branch],
+        &["diff", "--name-only", "HEAD", &origin_from],
         false,
         verbose,
     );

--- a/src/git.rs
+++ b/src/git.rs
@@ -107,3 +107,141 @@ pub fn get_review_branch_info(verbose: bool) -> Option<(String, String)> {
         None
     }
 }
+
+/// Resolved remote tracking branch information.
+pub struct ResolvedBranch {
+    /// The remote name (e.g. "origin", "upstream")
+    pub remote: String,
+    /// The local branch name on the remote (e.g. "develop", "feature/login")
+    pub remote_branch: String,
+    /// The full tracking ref (e.g. "origin/develop")
+    pub tracking_ref: String,
+}
+
+/// Resolves a branch name to its remote tracking branch information.
+///
+/// It checks:
+/// 1. If it's already a valid remote tracking branch (e.g., origin/main).
+/// 2. If it's a local branch with an upstream configured (e.g., @{upstream}).
+/// 3. Fallback: assumes it's on 'origin' if it exists there.
+pub fn resolve_remote_tracking_branch(branch_or_ref: &str, verbose: bool) -> ResolvedBranch {
+    // 1. Check if it's already a valid remote-tracking branch
+    let verify_output = run_git_command(
+        "verify if branch is already a remote tracking branch",
+        &[
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &format!("refs/remotes/{}", branch_or_ref),
+        ],
+        true,
+        verbose,
+    );
+
+    if verify_output.status.success() {
+        // It's a remote tracking branch. We need to split it into remote and branch.
+        // Assuming format is <remote>/<branch_name>. We can get remotes to find the remote name.
+        let remotes_output = run_git_command("get remotes", &["remote"], false, verbose);
+        let remotes_str = String::from_utf8_lossy(&remotes_output.stdout);
+        let mut best_remote = String::new();
+        for remote in remotes_str.lines() {
+            let remote = remote.trim();
+            if branch_or_ref.starts_with(&format!("{}/", remote)) {
+                if remote.len() > best_remote.len() {
+                    best_remote = remote.to_string();
+                }
+            }
+        }
+
+        if !best_remote.is_empty() {
+            let remote_branch = branch_or_ref
+                .strip_prefix(&format!("{}/", best_remote))
+                .unwrap()
+                .to_string();
+            return ResolvedBranch {
+                remote: best_remote,
+                remote_branch,
+                tracking_ref: branch_or_ref.to_string(),
+            };
+        }
+    }
+
+    // 2. Check if it's a local branch with an upstream configured
+    let upstream_output = run_git_command(
+        "get upstream branch",
+        &[
+            "rev-parse",
+            "--abbrev-ref",
+            &format!("{}@{{upstream}}", branch_or_ref),
+        ],
+        true,
+        verbose,
+    );
+
+    if upstream_output.status.success() {
+        let tracking_ref = String::from_utf8_lossy(&upstream_output.stdout)
+            .trim()
+            .to_string();
+
+        // Extract remote and remote_branch from tracking_ref using the configured remote for the branch
+        let remote_output = run_git_command(
+            "get configured remote",
+            &["config", &format!("branch.{}.remote", branch_or_ref)],
+            true,
+            verbose,
+        );
+
+        let remote = if remote_output.status.success() {
+            String::from_utf8_lossy(&remote_output.stdout)
+                .trim()
+                .to_string()
+        } else {
+            "origin".to_string() // fallback if something is weird
+        };
+
+        let remote_branch = if tracking_ref.starts_with(&format!("{}/", remote)) {
+            tracking_ref
+                .strip_prefix(&format!("{}/", remote))
+                .unwrap()
+                .to_string()
+        } else {
+            branch_or_ref.to_string() // fallback
+        };
+
+        return ResolvedBranch {
+            remote,
+            remote_branch,
+            tracking_ref,
+        };
+    }
+
+    // 3. Fallback: check if the branch exists on any remote (default to 'origin' if it's there)
+    // First, let's just see if it exists on origin.
+    let ls_remote_output = run_git_command(
+        "check if branch exists on origin",
+        &[
+            "ls-remote",
+            "--exit-code",
+            "origin",
+            &format!("refs/heads/{}", branch_or_ref),
+        ],
+        true,
+        verbose,
+    );
+
+    if ls_remote_output.status.success() {
+        return ResolvedBranch {
+            remote: "origin".to_string(),
+            remote_branch: branch_or_ref.to_string(),
+            tracking_ref: format!("origin/{}", branch_or_ref),
+        };
+    }
+
+    // If we reach here, we can't reliably resolve it. Default to origin/branch and let git fail natively later
+    // if it's really invalid.
+    ResolvedBranch {
+        remote: "origin".to_string(),
+        remote_branch: branch_or_ref.to_string(),
+        tracking_ref: format!("origin/{}", branch_or_ref),
+    }
+}

--- a/src/git.rs
+++ b/src/git.rs
@@ -146,10 +146,10 @@ pub fn resolve_remote_tracking_branch(branch_or_ref: &str, verbose: bool) -> Res
         let mut best_remote = String::new();
         for remote in remotes_str.lines() {
             let remote = remote.trim();
-            if branch_or_ref.starts_with(&format!("{}/", remote)) {
-                if remote.len() > best_remote.len() {
-                    best_remote = remote.to_string();
-                }
+            if branch_or_ref.starts_with(&format!("{}/", remote))
+                && remote.len() > best_remote.len()
+            {
+                best_remote = remote.to_string();
             }
         }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -656,3 +656,94 @@ fn test_review_with_stop_at_before_skip_to() {
         stderr
     );
 }
+
+/// Test that `cresca review` works with branch names containing slashes.
+#[test]
+fn test_review_with_slash_in_branch_name() {
+    let repo = TempGitRepo::new();
+    repo.create_branch("feature/login-page");
+    repo.write_file("login.txt", "login stuff");
+    repo.git(&["add", "."]);
+    repo.commit("Add login");
+    repo.git(&["push", "-u", "origin", "feature/login-page"]);
+
+    repo.switch_branch("main");
+    let output = repo.run_cresca(&["review", "main", "feature/login-page"]);
+    assert!(
+        output.status.success(),
+        "cresca review should succeed with slash in branch name\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Test that `cresca review` works when the local branch does not exist.
+#[test]
+fn test_review_without_local_branch() {
+    let repo = TempGitRepo::new();
+    // Simulate another user pushing a branch
+    repo.create_branch("other-users-feature");
+    repo.write_file("other.txt", "other stuff");
+    repo.git(&["add", "."]);
+    repo.commit("Add other stuff");
+    repo.git(&["push", "-u", "origin", "other-users-feature"]);
+
+    // Switch to main and completely delete the local branch
+    repo.switch_branch("main");
+    repo.git(&["branch", "-D", "other-users-feature"]);
+
+    let output = repo.run_cresca(&["review", "main", "other-users-feature"]);
+    assert!(
+        output.status.success(),
+        "cresca review should succeed even if local branch does not exist\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Test that `cresca review` works with a custom remote name (e.g. upstream).
+#[test]
+fn test_review_with_custom_remote() {
+    // This is tricky with TempGitRepo since it sets up 'origin' by default.
+    // We will rename the remote to 'upstream' for this test.
+    let repo = TempGitRepo::new();
+    repo.git(&["remote", "rename", "origin", "upstream"]);
+
+    repo.create_branch("develop");
+    repo.write_file("dev.txt", "dev stuff");
+    repo.git(&["add", "."]);
+    repo.commit("Add dev stuff");
+    // Push setting upstream explicitly
+    repo.git(&["push", "-u", "upstream", "develop"]);
+    repo.git(&["push", "-u", "upstream", "main"]);
+
+    repo.switch_branch("main");
+    let output = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        output.status.success(),
+        "cresca review should succeed with a custom remote named 'upstream'\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Test that `cresca review` works when given remote tracking branch explicitly.
+#[test]
+fn test_review_with_explicit_remote_tracking_branch() {
+    let repo = TempGitRepo::new();
+    repo.create_branch("develop");
+    repo.write_file("dev.txt", "dev stuff");
+    repo.git(&["add", "."]);
+    repo.commit("Add dev stuff");
+    repo.git(&["push", "-u", "origin", "develop"]);
+
+    repo.switch_branch("main");
+    // Pass 'origin/develop' instead of 'develop'
+    let output = repo.run_cresca(&["review", "main", "origin/develop"]);
+    assert!(
+        output.status.success(),
+        "cresca review should succeed with explicit remote tracking branch\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
Use remote tracking branches instead of checking out and pulling local branches when running `cresca review`. This avoids git switch errors when branches are checked out in other worktrees. Also added `--ff` to squash merge to support `--no-ff` git global config.

---
*PR created automatically by Jules for task [2474398693719359491](https://jules.google.com/task/2474398693719359491) started by @Lfu001*