### PR TITLE
fix(commands): remove redundant format argument borrow

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -165,7 +165,7 @@ pub fn prepare_review_branch(
         // Check if there are commits before skip_to
         let has_earlier = run_git_command(
             "check earlier commits",
-            &["rev-list", &format!("{}..{}", merge_base, &parent)],
+            &["rev-list", &format!("{}..{}", merge_base, parent)],
             true,
             verbose,
         );


### PR DESCRIPTION
The `main` CI now passes on the latest stable Rust toolchain by removing a redundant borrow that Clippy 1.97 promoted to an error under `-D warnings`. This resolves the post-merge lint failure without changing runtime behavior.