### PR TITLE
fix(review): identify review branches with metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Also You need to have `git` installed.
 
 ## Usage
 
-1. Start a review by specifying the branches. Following example will prepare a review branch (named `review-main-develop`) for the PR that `develop` is to be merged into `main`.
+1. Start a review by specifying the branches. Following example will prepare a review branch (typically named `review-main-develop`) for the PR that `develop` is to be merged into `main`.
 
     ```sh
     cresca review main develop
@@ -63,12 +63,6 @@ cresca review main develop --stop-at=C
 ```
 
 Use `git log --oneline main..develop` to see available commits.
-
-### Review Branch Identity
-
-Cresca records the target and source in local Git configuration for each review branch. `approve` and `status` accept only branches with valid Cresca metadata; a branch is never identified from its name alone.
-
-The usual readable name (`review-main-develop`) is retained. If that name is already used by another or older metadata-free review, Cresca leaves it untouched and creates a deterministic suffixed name. Review branches made by older Cresca versions are not guessed or migrated because names containing `-`, `/`, or `_` can be ambiguous. Run `cresca review <target> <source>` again to create a metadata-backed branch, inspect the new diff, and then remove the old local branch manually when it is no longer needed.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ cresca review main develop --stop-at=C
 
 Use `git log --oneline main..develop` to see available commits.
 
+### Review Branch Identity
+
+Cresca records the target and source in local Git configuration for each review branch. `approve` and `status` accept only branches with valid Cresca metadata; a branch is never identified from its name alone.
+
+The usual readable name (`review-main-develop`) is retained. If that name is already used by another or older metadata-free review, Cresca leaves it untouched and creates a deterministic suffixed name. Review branches made by older Cresca versions are not guessed or migrated because names containing `-`, `/`, or `_` can be ambiguous. Run `cresca review <target> <source>` again to create a metadata-backed branch, inspect the new diff, and then remove the old local branch manually when it is no longer needed.
+
 ## License
 
 [MIT](https://github.com/Lfu001/cresca/blob/main/LICENSE)

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,5 +1,6 @@
 use crate::git::{
-    resolve_remote_tracking_branch, run_git_command, write_review_metadata, ReviewMetadata,
+    resolve_remote_tracking_branch, run_git_command, select_review_branch, write_review_metadata,
+    ReviewBranchSelection, ReviewMetadata,
 };
 use colored::Colorize;
 use std::ops::Not;
@@ -25,8 +26,6 @@ pub fn prepare_review_branch(
         target: to_branch.to_string(),
         source: from_branch.to_string(),
     };
-    let review_branch = format!("review-{}-{}", to_branch, from_branch).replace("/", "_");
-
     let resolved_to = resolve_remote_tracking_branch(to_branch, verbose);
     let resolved_from = resolve_remote_tracking_branch(from_branch, verbose);
 
@@ -131,37 +130,26 @@ pub fn prepare_review_branch(
         }
     }
 
-    // Check if review branch exists
-    let review_branch_exists = run_git_command(
-        "check existence of review branch",
-        &[
-            "show-ref",
-            "--verify",
-            &format!("refs/heads/{}", review_branch),
-        ],
-        true,
-        verbose,
-    )
-    .status
-    .success();
-
-    if review_branch_exists {
-        // Switch to existing review branch
-        run_git_command(
-            "switch to review branch",
-            &["switch", &review_branch],
-            false,
-            verbose,
-        );
-    } else {
-        // Create review branch from merge-base
-        run_git_command(
-            "create review branch from merge-base",
-            &["checkout", "-b", &review_branch, &merge_base],
-            false,
-            verbose,
-        );
-    }
+    let (review_branch, is_new) = match select_review_branch(&metadata, verbose) {
+        ReviewBranchSelection::Existing(name) => {
+            run_git_command(
+                "switch to review branch",
+                &["switch", &name],
+                false,
+                verbose,
+            );
+            (name, false)
+        }
+        ReviewBranchSelection::New(name) => {
+            run_git_command(
+                "create review branch from merge-base",
+                &["checkout", "-b", &name, &merge_base],
+                false,
+                verbose,
+            );
+            (name, true)
+        }
+    };
 
     // Determine target commit for squash merge
     let target_commit = if let Some(hash) = skip_to {
@@ -226,7 +214,9 @@ pub fn prepare_review_branch(
 
     // Unstage changes for review
     run_git_command("unstage changes for review", &["reset"], false, verbose);
-    write_review_metadata(&review_branch, &metadata, verbose);
+    if is_new {
+        write_review_metadata(&review_branch, &metadata, verbose);
+    }
 }
 
 /// Commit reviewed changes and discard unreviewed ones

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,4 +1,6 @@
-use crate::git::{resolve_remote_tracking_branch, run_git_command};
+use crate::git::{
+    resolve_remote_tracking_branch, run_git_command, write_review_metadata, ReviewMetadata,
+};
 use colored::Colorize;
 use std::ops::Not;
 use std::process::exit;
@@ -19,6 +21,10 @@ pub fn prepare_review_branch(
     stop_at: Option<&str>,
     verbose: bool,
 ) {
+    let metadata = ReviewMetadata {
+        target: to_branch.to_string(),
+        source: from_branch.to_string(),
+    };
     let review_branch = format!("review-{}-{}", to_branch, from_branch).replace("/", "_");
 
     let resolved_to = resolve_remote_tracking_branch(to_branch, verbose);
@@ -220,6 +226,7 @@ pub fn prepare_review_branch(
 
     // Unstage changes for review
     run_git_command("unstage changes for review", &["reset"], false, verbose);
+    write_review_metadata(&review_branch, &metadata, verbose);
 }
 
 /// Commit reviewed changes and discard unreviewed ones

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,6 +1,120 @@
 use colored::Colorize;
 use std::process::{exit, Command, Output};
 
+pub const REVIEW_METADATA_VERSION: &str = "1";
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ReviewMetadata {
+    pub target: String,
+    pub source: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum ReviewMetadataError {
+    Missing,
+    UnsupportedVersion(String),
+    Invalid,
+}
+
+fn review_config_key(branch: &str, field: &str) -> String {
+    format!("branch.{branch}.cresca-{field}")
+}
+
+#[allow(dead_code)]
+fn review_config_values(branch: &str, field: &str, verbose: bool) -> Vec<String> {
+    let key = review_config_key(branch, field);
+    let output = run_git_command(
+        "read review metadata",
+        &["config", "--local", "--get-all", &key],
+        true,
+        verbose,
+    );
+    if !output.status.success() {
+        return Vec::new();
+    }
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::to_owned)
+        .collect()
+}
+
+#[allow(dead_code)]
+pub fn read_review_metadata(
+    branch: &str,
+    verbose: bool,
+) -> Result<ReviewMetadata, ReviewMetadataError> {
+    let versions = review_config_values(branch, "version", verbose);
+    let targets = review_config_values(branch, "target", verbose);
+    let sources = review_config_values(branch, "source", verbose);
+
+    match (versions.as_slice(), targets.as_slice(), sources.as_slice()) {
+        ([version], [target], [source])
+            if version == REVIEW_METADATA_VERSION && !target.is_empty() && !source.is_empty() =>
+        {
+            Ok(ReviewMetadata {
+                target: target.clone(),
+                source: source.clone(),
+            })
+        }
+        ([], [], []) => Err(ReviewMetadataError::Missing),
+        ([version], _, _) if version != REVIEW_METADATA_VERSION => {
+            Err(ReviewMetadataError::UnsupportedVersion(version.clone()))
+        }
+        _ => Err(ReviewMetadataError::Invalid),
+    }
+}
+
+pub fn write_review_metadata(branch: &str, metadata: &ReviewMetadata, verbose: bool) {
+    let version_key = review_config_key(branch, "version");
+    let target_key = review_config_key(branch, "target");
+    let source_key = review_config_key(branch, "source");
+
+    run_git_command(
+        "clear review metadata version marker",
+        &["config", "--local", "--unset-all", &version_key],
+        true,
+        verbose,
+    );
+    run_git_command(
+        "record review target",
+        &[
+            "config",
+            "--local",
+            "--replace-all",
+            &target_key,
+            &metadata.target,
+        ],
+        false,
+        verbose,
+    );
+    run_git_command(
+        "record review source",
+        &[
+            "config",
+            "--local",
+            "--replace-all",
+            &source_key,
+            &metadata.source,
+        ],
+        false,
+        verbose,
+    );
+    run_git_command(
+        "commit review metadata",
+        &[
+            "config",
+            "--local",
+            "--replace-all",
+            &version_key,
+            REVIEW_METADATA_VERSION,
+        ],
+        false,
+        verbose,
+    );
+}
+
 /// Run a git command and return the output
 ///
 /// # Arguments

--- a/src/git.rs
+++ b/src/git.rs
@@ -66,19 +66,23 @@ fn local_branch_exists(branch: &str, verbose: bool) -> bool {
 
 pub fn select_review_branch(metadata: &ReviewMetadata, verbose: bool) -> ReviewBranchSelection {
     let base = readable_review_branch(metadata);
-    if !local_branch_exists(&base, verbose) {
-        return ReviewBranchSelection::New(base);
-    }
-    if read_review_metadata(&base, verbose).as_ref() == Ok(metadata) {
-        return ReviewBranchSelection::Existing(base);
+    let base_exists = local_branch_exists(&base, verbose);
+    match (base_exists, read_review_metadata(&base, verbose)) {
+        (false, Err(ReviewMetadataError::Missing)) => return ReviewBranchSelection::New(base),
+        (true, Ok(existing)) if existing == *metadata => {
+            return ReviewBranchSelection::Existing(base)
+        }
+        _ => {}
     }
 
     let suffix = suffixed_review_branch(&base, metadata);
-    if !local_branch_exists(&suffix, verbose) {
-        return ReviewBranchSelection::New(suffix);
-    }
-    if read_review_metadata(&suffix, verbose).as_ref() == Ok(metadata) {
-        return ReviewBranchSelection::Existing(suffix);
+    let suffix_exists = local_branch_exists(&suffix, verbose);
+    match (suffix_exists, read_review_metadata(&suffix, verbose)) {
+        (false, Err(ReviewMetadataError::Missing)) => return ReviewBranchSelection::New(suffix),
+        (true, Ok(existing)) if existing == *metadata => {
+            return ReviewBranchSelection::Existing(suffix)
+        }
+        _ => {}
     }
 
     eprintln!(
@@ -102,14 +106,21 @@ fn review_config_values(branch: &str, field: &str, verbose: bool) -> Vec<String>
         true,
         verbose,
     );
-    if !output.status.success() {
+    if output.status.success() {
+        return String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .map(str::to_owned)
+            .collect();
+    }
+
+    if output.status.code() == Some(1) && output.stderr.is_empty() {
         return Vec::new();
     }
 
-    String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .map(str::to_owned)
-        .collect()
+    eprintln!("{}: Failed to read review metadata.", "error".red().bold());
+    eprintln!("Original error from git:");
+    eprintln!("\t{}", String::from_utf8_lossy(&output.stderr));
+    exit(1);
 }
 
 pub fn read_review_metadata(

--- a/src/git.rs
+++ b/src/git.rs
@@ -142,12 +142,15 @@ pub fn write_review_metadata(branch: &str, metadata: &ReviewMetadata, verbose: b
     let target_key = review_config_key(branch, "target");
     let source_key = review_config_key(branch, "source");
 
-    run_git_command(
-        "clear review metadata version marker",
-        &["config", "--local", "--unset-all", &version_key],
-        true,
-        verbose,
-    );
+    let existing_versions = review_config_values(branch, "version", verbose);
+    if !existing_versions.is_empty() {
+        run_git_command(
+            "clear review metadata version marker",
+            &["config", "--local", "--unset-all", &version_key],
+            false,
+            verbose,
+        );
+    }
     run_git_command(
         "record review target",
         &[
@@ -398,5 +401,23 @@ pub fn resolve_remote_tracking_branch(branch_or_ref: &str, verbose: bool) -> Res
         remote: "origin".to_string(),
         remote_branch: branch_or_ref.to_string(),
         tracking_ref: format!("origin/{}", branch_or_ref),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{suffixed_review_branch, ReviewMetadata};
+
+    #[test]
+    fn review_identity_suffix_matches_fixed_length_framed_fnv1a_vector() {
+        let metadata = ReviewMetadata {
+            target: "main".to_string(),
+            source: "feature/foo".to_string(),
+        };
+
+        assert_eq!(
+            suffixed_review_branch("review-main-feature_foo", &metadata),
+            "review-main-feature_foo-49caf74ca44ff0fe"
+        );
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -10,8 +10,8 @@ pub struct ReviewMetadata {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-#[allow(dead_code)]
 pub enum ReviewMetadataError {
+    InvalidBranchName,
     Missing,
     UnsupportedVersion(String),
     Invalid,
@@ -21,7 +21,6 @@ fn review_config_key(branch: &str, field: &str) -> String {
     format!("branch.{branch}.cresca-{field}")
 }
 
-#[allow(dead_code)]
 fn review_config_values(branch: &str, field: &str, verbose: bool) -> Vec<String> {
     let key = review_config_key(branch, field);
     let output = run_git_command(
@@ -40,7 +39,6 @@ fn review_config_values(branch: &str, field: &str, verbose: bool) -> Vec<String>
         .collect()
 }
 
-#[allow(dead_code)]
 pub fn read_review_metadata(
     branch: &str,
     verbose: bool,
@@ -174,52 +172,22 @@ pub fn is_clean(verbose: bool) -> bool {
     .is_empty()
 }
 
-/// Check if the current branch is a review branch
-///
-/// # Arguments
-///
-/// * `verbose` - Whether to print the git command and its output.
-pub fn is_review_branch(verbose: bool) -> bool {
+pub fn current_branch_name(verbose: bool) -> String {
     let output = run_git_command(
         "get current branch",
         &["rev-parse", "--abbrev-ref", "HEAD"],
         false,
         verbose,
     );
-    let branch_name = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    branch_name.starts_with("review")
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
 }
 
-/// Get review branch info (to_branch, from_branch) from current branch name
-///
-/// # Arguments
-///
-/// * `verbose` - Whether to print the git command and its output.
-///
-/// # Returns
-///
-/// * `Option<(String, String)>` - (to_branch, from_branch) if on a review branch, None otherwise
-pub fn get_review_branch_info(verbose: bool) -> Option<(String, String)> {
-    let output = run_git_command(
-        "get current branch",
-        &["rev-parse", "--abbrev-ref", "HEAD"],
-        false,
-        verbose,
-    );
-    let branch_name = String::from_utf8_lossy(&output.stdout).trim().to_string();
-
-    if !branch_name.starts_with("review-") {
-        return None;
+pub fn current_review_metadata(verbose: bool) -> Result<ReviewMetadata, ReviewMetadataError> {
+    let branch = current_branch_name(verbose);
+    if !branch.starts_with("review-") {
+        return Err(ReviewMetadataError::InvalidBranchName);
     }
-
-    // Parse "review-{to}-{from}" format
-    let rest = branch_name.strip_prefix("review-")?;
-    let parts: Vec<&str> = rest.splitn(2, '-').collect();
-    if parts.len() == 2 {
-        Some((parts[0].to_string(), parts[1].to_string()))
-    } else {
-        None
-    }
+    read_review_metadata(&branch, verbose)
 }
 
 /// Resolved remote tracking branch information.

--- a/src/git.rs
+++ b/src/git.rs
@@ -17,6 +17,79 @@ pub enum ReviewMetadataError {
     Invalid,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum ReviewBranchSelection {
+    New(String),
+    Existing(String),
+}
+
+fn readable_review_branch(metadata: &ReviewMetadata) -> String {
+    format!("review-{}-{}", metadata.target, metadata.source).replace('/', "_")
+}
+
+fn review_identity_hash(metadata: &ReviewMetadata) -> u64 {
+    const OFFSET: u64 = 0xcbf29ce484222325;
+    const PRIME: u64 = 0x100000001b3;
+    let mut hash = OFFSET;
+    let mut feed = |bytes: &[u8]| {
+        for byte in bytes {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(PRIME);
+        }
+    };
+    feed(&(metadata.target.len() as u64).to_be_bytes());
+    feed(metadata.target.as_bytes());
+    feed(&(metadata.source.len() as u64).to_be_bytes());
+    feed(metadata.source.as_bytes());
+    hash
+}
+
+fn suffixed_review_branch(base: &str, metadata: &ReviewMetadata) -> String {
+    format!("{base}-{:016x}", review_identity_hash(metadata))
+}
+
+fn local_branch_exists(branch: &str, verbose: bool) -> bool {
+    run_git_command(
+        "check existence of review branch",
+        &[
+            "show-ref",
+            "--verify",
+            "--quiet",
+            &format!("refs/heads/{branch}"),
+        ],
+        true,
+        verbose,
+    )
+    .status
+    .success()
+}
+
+pub fn select_review_branch(metadata: &ReviewMetadata, verbose: bool) -> ReviewBranchSelection {
+    let base = readable_review_branch(metadata);
+    if !local_branch_exists(&base, verbose) {
+        return ReviewBranchSelection::New(base);
+    }
+    if read_review_metadata(&base, verbose).as_ref() == Ok(metadata) {
+        return ReviewBranchSelection::Existing(base);
+    }
+
+    let suffix = suffixed_review_branch(&base, metadata);
+    if !local_branch_exists(&suffix, verbose) {
+        return ReviewBranchSelection::New(suffix);
+    }
+    if read_review_metadata(&suffix, verbose).as_ref() == Ok(metadata) {
+        return ReviewBranchSelection::Existing(suffix);
+    }
+
+    eprintln!(
+        "{}: Found conflicting review branches `{}` and `{}` with missing, invalid, or different metadata. Inspect and delete or rename the conflicting local review branch before retrying.",
+        "error".red().bold(),
+        base,
+        suffix
+    );
+    exit(1);
+}
+
 fn review_config_key(branch: &str, field: &str) -> String {
     format!("branch.{branch}.cresca-{field}")
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use clap::builder::styling::{AnsiColor, Effects};
 use clap::{builder::Styles, ArgAction, Args, Parser, Subcommand};
 use colored::Colorize;
 use commands::{approve_changes, get_review_status, prepare_review_branch};
-use git::{get_review_branch_info, is_clean, is_review_branch};
+use git::{current_review_metadata, is_clean, ReviewMetadataError};
 use std::process::exit;
 
 const STYLES: Styles = Styles::styled()
@@ -67,22 +67,14 @@ fn main() {
 
     match &cli.command {
         Commands::Approve => {
-            if is_review_branch(cli.verbose) {
-                let res = approve_changes(cli.verbose);
-                match res {
-                    Err(_) => {
-                        println!("There are no reviewed changes to approve. Ending the review.",)
-                    }
-                    Ok(_) => println!("Reviewed changes were approved successfully.",),
-                };
-            } else {
-                eprintln!(
-                    "{}: Not on a review branch; run `{}` to prepare a review branch.",
-                    "error".red().bold(),
-                    "cresca review".green()
-                );
-                exit(1);
+            if let Err(error) = current_review_metadata(cli.verbose) {
+                exit_invalid_review_branch(error);
             }
+            let res = approve_changes(cli.verbose);
+            match res {
+                Err(_) => println!("There are no reviewed changes to approve. Ending the review."),
+                Ok(_) => println!("Reviewed changes were approved successfully."),
+            };
         }
         Commands::Review(args) => {
             if !is_clean(cli.verbose) {
@@ -104,37 +96,39 @@ fn main() {
             }
         }
         Commands::Status => {
-            if let Some((_, from_branch)) = get_review_branch_info(cli.verbose) {
-                let status = get_review_status(&from_branch, cli.verbose);
-                println!("📋 Review status:");
-                println!(
-                    "  Remaining diff to {}: {} file(s), {} insertion(s), {} deletion(s)",
-                    status.from_branch.green(),
-                    status.file_count.to_string().yellow(),
-                    format!("+{}", status.insertions).green(),
-                    format!("-{}", status.deletions).red()
-                );
-                if !status.files.is_empty() {
-                    const MAX_FILES: usize = 10;
-                    println!("  Files remaining:");
-                    for file in status.files.iter().take(MAX_FILES) {
-                        println!("    - {}", file);
-                    }
-                    if status.files.len() > MAX_FILES {
-                        println!(
-                            "    ... and {} more file(s)",
-                            status.files.len() - MAX_FILES
-                        );
-                    }
+            let metadata = current_review_metadata(cli.verbose)
+                .unwrap_or_else(|error| exit_invalid_review_branch(error));
+            let status = get_review_status(&metadata.source, cli.verbose);
+            println!("📋 Review status:");
+            println!(
+                "  Remaining diff to {}: {} file(s), {} insertion(s), {} deletion(s)",
+                status.from_branch.green(),
+                status.file_count.to_string().yellow(),
+                format!("+{}", status.insertions).green(),
+                format!("-{}", status.deletions).red()
+            );
+            if !status.files.is_empty() {
+                const MAX_FILES: usize = 10;
+                println!("  Files remaining:");
+                for file in status.files.iter().take(MAX_FILES) {
+                    println!("    - {}", file);
                 }
-            } else {
-                eprintln!(
-                    "{}: Not on a review branch; run `{}` to prepare a review branch.",
-                    "error".red().bold(),
-                    "cresca review".green()
-                );
-                exit(1);
+                if status.files.len() > MAX_FILES {
+                    println!(
+                        "    ... and {} more file(s)",
+                        status.files.len() - MAX_FILES
+                    );
+                }
             }
         }
     }
+}
+
+fn exit_invalid_review_branch(_: ReviewMetadataError) -> ! {
+    eprintln!(
+        "{}: Current branch is not a valid cresca review branch because its metadata is missing or invalid; run `{}` to prepare one.",
+        "error".red().bold(),
+        "cresca review <target> <source>".green()
+    );
+    exit(1);
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -15,6 +15,7 @@ pub struct RepoState {
     pub branch: String,
     pub head: String,
     pub local_heads: Vec<u8>,
+    pub local_config: Vec<u8>,
     pub status: Vec<u8>,
     pub cached_diff: Vec<u8>,
     pub worktree_diff: Vec<u8>,
@@ -92,6 +93,26 @@ impl TempGitRepo {
             .expect("git stdout should be UTF-8")
             .trim()
             .to_string()
+    }
+
+    pub fn git_config_values(&self, key: &str) -> Vec<String> {
+        let output = self.git_maybe(&["config", "--local", "--get-all", key]);
+        if !output.status.success() {
+            return Vec::new();
+        }
+        String::from_utf8(output.stdout)
+            .expect("git config value should be UTF-8")
+            .lines()
+            .map(str::to_owned)
+            .collect()
+    }
+
+    pub fn review_metadata_values(&self, branch: &str) -> (Vec<String>, Vec<String>, Vec<String>) {
+        (
+            self.git_config_values(&format!("branch.{branch}.cresca-version")),
+            self.git_config_values(&format!("branch.{branch}.cresca-target")),
+            self.git_config_values(&format!("branch.{branch}.cresca-source")),
+        )
     }
 
     /// Resolves a revision to its object ID.
@@ -194,6 +215,9 @@ impl TempGitRepo {
                     "--format=%(refname) %(objectname)",
                     "refs/heads/",
                 ])
+                .stdout,
+            local_config: self
+                .git(&["config", "--local", "--null", "--list", "--show-origin"])
                 .stdout,
             status: self
                 .git(&["status", "--porcelain=v1", "-z", "--untracked-files=all"])

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,6 +3,14 @@ mod common;
 use common::TempGitRepo;
 use std::collections::BTreeSet;
 
+struct RemoveFileOnDrop(std::path::PathBuf);
+
+impl Drop for RemoveFileOnDrop {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
 struct LinearRange {
     base: String,
     a: String,
@@ -522,6 +530,8 @@ fn test_failed_review_preparation_does_not_commit_review_metadata() {
     let output = std::process::Command::new(TempGitRepo::cresca_binary())
         .args(["review", "main", "develop", "--skip-to", &range.b[..8]])
         .env("NO_COLOR", "1")
+        .env("LC_ALL", "C")
+        .env("LANG", "C")
         // Isolate a possible global identity so the commit failure is reproducible.
         .env(
             "GIT_CONFIG_GLOBAL",
@@ -1078,6 +1088,65 @@ fn test_review_records_versioned_target_and_source_metadata() {
             "origin/feature/login-page",
         )
     );
+}
+
+#[test]
+fn test_review_stops_when_existing_metadata_version_cannot_be_cleared() {
+    let repo = TempGitRepo::new();
+
+    repo.create_branch("develop");
+    repo.write_file("develop.txt", "develop change\n");
+    repo.git(&["add", "."]);
+    repo.commit("Add develop change");
+    repo.git(&["push", "-u", "origin", "develop"]);
+    repo.switch_branch("main");
+
+    let review_branch = "review-main-develop";
+    repo.git(&[
+        "config",
+        "--local",
+        &format!("branch.{review_branch}.cresca-version"),
+        "1",
+    ]);
+    repo.git(&[
+        "config",
+        "--local",
+        &format!("branch.{review_branch}.cresca-target"),
+        "main",
+    ]);
+    repo.git(&[
+        "config",
+        "--local",
+        &format!("branch.{review_branch}.cresca-source"),
+        "develop",
+    ]);
+    let metadata_before = repo.review_metadata_values(review_branch);
+
+    let config_lock_path = repo.path().join(".git/config.lock");
+    std::fs::write(&config_lock_path, "lock metadata writes")
+        .expect("config lock fixture should be writable");
+    let config_lock_cleanup = RemoveFileOnDrop(config_lock_path);
+
+    let output = repo.run_cresca(&["--verbose", "review", "main", "develop"]);
+    drop(config_lock_cleanup);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Failed to clear review metadata version marker"),
+        "expected version-clear failure, got: {stderr}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(&format!(
+        "git config --local --unset-all branch.{review_branch}.cresca-version"
+    )));
+    assert!(
+        !stdout.contains(&format!(
+            "git config --local --replace-all branch.{review_branch}.cresca-target"
+        )),
+        "metadata writes must stop after the version marker cannot be cleared: {stdout}"
+    );
+    assert_eq!(repo.review_metadata_values(review_branch), metadata_before);
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -434,6 +434,10 @@ fn test_review_with_uncommitted_changes() {
     );
     assert_eq!(repo.snapshot(), before);
     assert!(!repo.ref_exists("refs/heads/review-main-develop"));
+    assert_eq!(
+        repo.review_metadata_values("review-main-develop"),
+        (Vec::new(), Vec::new(), Vec::new())
+    );
 }
 
 /// Test that running review twice updates the review branch correctly.
@@ -528,6 +532,38 @@ fn test_review_with_skip_to_first_commit_keeps_full_range_unstaged() {
     assert_eq!(repo.rev_parse("HEAD"), range.base);
     assert!(repo.cached_diff().is_empty());
     assert_eq!(repo.worktree_diff(), repo.diff(&range.base, &range.d));
+}
+
+#[test]
+fn test_failed_review_preparation_does_not_commit_review_metadata() {
+    let (repo, range) = setup_linear_range();
+    repo.git(&["config", "user.useConfigOnly", "true"]);
+    repo.git(&["config", "--unset-all", "user.email"]);
+
+    let output = std::process::Command::new(TempGitRepo::cresca_binary())
+        .args(["review", "main", "develop", "--skip-to", &range.b[..8]])
+        .env("NO_COLOR", "1")
+        // Isolate a possible global identity so the commit failure is reproducible.
+        .env(
+            "GIT_CONFIG_GLOBAL",
+            repo.path().join("missing-global-gitconfig"),
+        )
+        .current_dir(repo.path())
+        .output()
+        .expect("Failed to execute cresca");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("commit auto-approved changes")
+            && stderr.contains("Author identity unknown"),
+        "expected failed Git commit diagnostic, got: {stderr}"
+    );
+    assert_eq!(
+        repo.review_metadata_values("review-main-develop"),
+        (Vec::new(), Vec::new(), Vec::new()),
+        "a failed materialization must not be marked as valid review state",
+    );
 }
 
 /// Test that `cresca review --skip-to` with already approved commits works correctly.
@@ -925,6 +961,10 @@ fn test_review_with_invalid_stop_at() {
     );
     assert_eq!(repo.snapshot(), before);
     assert!(!repo.ref_exists("refs/heads/review-main-develop"));
+    assert_eq!(
+        repo.review_metadata_values("review-main-develop"),
+        (Vec::new(), Vec::new(), Vec::new())
+    );
 }
 
 #[test]
@@ -945,6 +985,10 @@ fn test_review_with_nonexistent_skip_to_is_atomic() {
     );
     assert_eq!(repo.snapshot(), before);
     assert!(!repo.ref_exists("refs/heads/review-main-develop"));
+    assert_eq!(
+        repo.review_metadata_values("review-main-develop"),
+        (Vec::new(), Vec::new(), Vec::new())
+    );
 }
 
 #[test]
@@ -971,6 +1015,10 @@ fn test_review_with_out_of_range_skip_to_is_atomic() {
     );
     assert_eq!(repo.snapshot(), before);
     assert!(!repo.ref_exists("refs/heads/review-main-develop"));
+    assert_eq!(
+        repo.review_metadata_values("review-main-develop"),
+        (Vec::new(), Vec::new(), Vec::new())
+    );
 }
 
 /// Test that `cresca review` fails when --stop-at is before --skip-to.
@@ -1001,6 +1049,10 @@ fn test_review_with_stop_at_before_skip_to() {
     );
     assert_eq!(repo.snapshot(), before);
     assert!(!repo.ref_exists("refs/heads/review-main-develop"));
+    assert_eq!(
+        repo.review_metadata_values("review-main-develop"),
+        (Vec::new(), Vec::new(), Vec::new())
+    );
 }
 
 /// Test that `cresca review` records the exact CLI target and source values.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -63,6 +63,19 @@ fn assert_review_matches(
     assert_eq!(repo.worktree_diff(), repo.diff(&merge_base, source_ref));
 }
 
+fn assert_identity_suffixed_branch(branch: &str, base: &str) {
+    let suffix = branch
+        .strip_prefix(&format!("{base}-"))
+        .expect("review branch should retain the readable base name");
+    assert_eq!(suffix.len(), 16);
+    assert!(
+        suffix
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
+        "identity suffix should be 16 lowercase hexadecimal characters: {branch}"
+    );
+}
+
 fn prepare_staged_unstaged_and_untracked_changes(repo: &TempGitRepo) {
     repo.write_file("staged.txt", "staged base\n");
     repo.write_file("unstaged.txt", "unstaged base\n");
@@ -1039,6 +1052,264 @@ fn test_review_records_versioned_target_and_source_metadata() {
             "origin/feature/login-page",
         )
     );
+}
+
+#[test]
+fn test_review_does_not_reuse_branch_for_slash_underscore_collision() {
+    let repo = TempGitRepo::new();
+
+    repo.create_branch("feature/foo");
+    repo.write_file("slash.txt", "slash branch\n");
+    repo.git(&["add", "."]);
+    repo.commit("Add slash branch change");
+    repo.git(&["push", "-u", "origin", "feature/foo"]);
+
+    repo.switch_branch("main");
+    repo.create_branch("feature_foo");
+    repo.write_file("underscore.txt", "underscore branch\n");
+    repo.git(&["add", "."]);
+    repo.commit("Add underscore branch change");
+    repo.git(&["push", "-u", "origin", "feature_foo"]);
+
+    repo.switch_branch("main");
+    let first = repo.run_cresca(&["review", "main", "feature/foo"]);
+    assert!(first.status.success());
+    assert_eq!(repo.current_branch(), "review-main-feature_foo");
+    assert!(repo.run_cresca(&["approve"]).status.success());
+    repo.switch_branch("main");
+    let first_oid = repo.rev_parse("refs/heads/review-main-feature_foo");
+
+    let second = repo.run_cresca(&["review", "main", "feature_foo"]);
+    assert!(
+        second.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&second.stdout),
+        String::from_utf8_lossy(&second.stderr)
+    );
+    let second_branch = repo.current_branch();
+    assert_ne!(second_branch, "review-main-feature_foo");
+    assert_identity_suffixed_branch(&second_branch, "review-main-feature_foo");
+    assert_eq!(
+        repo.rev_parse("refs/heads/review-main-feature_foo"),
+        first_oid
+    );
+    assert_eq!(
+        repo.review_metadata_values(&second_branch),
+        (
+            vec!["1".to_string()],
+            vec!["main".to_string()],
+            vec!["feature_foo".to_string()],
+        )
+    );
+    assert!(repo.cached_diff().is_empty());
+    let merge_base = repo.git_stdout(&["merge-base", "origin/main", "origin/feature_foo"]);
+    assert_eq!(
+        repo.worktree_diff(),
+        repo.diff(&merge_base, "origin/feature_foo")
+    );
+    assert!(!repo.path().join("slash.txt").exists());
+    assert_eq!(repo.read_file("underscore.txt"), "underscore branch\n");
+}
+
+#[test]
+fn test_review_does_not_reuse_branch_for_ambiguous_pair_boundary() {
+    let repo = TempGitRepo::new();
+
+    repo.create_branch("release");
+    repo.git(&["push", "-u", "origin", "release"]);
+    repo.create_branch("v1-feature");
+    repo.write_file("pair-one.txt", "first pair\n");
+    repo.git(&["add", "."]);
+    repo.commit("Add first pair change");
+    repo.git(&["push", "-u", "origin", "v1-feature"]);
+
+    repo.switch_branch("main");
+    repo.create_branch("release-v1");
+    repo.write_file("release-v1-base.txt", "second target base\n");
+    repo.git(&["add", "."]);
+    repo.commit("Add second target base");
+    repo.git(&["push", "-u", "origin", "release-v1"]);
+    repo.create_branch("feature");
+    repo.write_file("pair-two.txt", "second pair\n");
+    repo.git(&["add", "."]);
+    repo.commit("Add second pair change");
+    repo.git(&["push", "-u", "origin", "feature"]);
+
+    repo.switch_branch("main");
+    let first = repo.run_cresca(&["review", "release", "v1-feature"]);
+    assert!(first.status.success());
+    assert_eq!(repo.current_branch(), "review-release-v1-feature");
+    assert!(repo.run_cresca(&["approve"]).status.success());
+    repo.switch_branch("main");
+    let first_oid = repo.rev_parse("refs/heads/review-release-v1-feature");
+
+    let second = repo.run_cresca(&["review", "release-v1", "feature"]);
+    assert!(
+        second.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&second.stdout),
+        String::from_utf8_lossy(&second.stderr)
+    );
+    let second_branch = repo.current_branch();
+    assert_ne!(second_branch, "review-release-v1-feature");
+    assert_identity_suffixed_branch(&second_branch, "review-release-v1-feature");
+    assert_eq!(
+        repo.rev_parse("refs/heads/review-release-v1-feature"),
+        first_oid
+    );
+    assert_eq!(
+        repo.review_metadata_values(&second_branch),
+        (
+            vec!["1".to_string()],
+            vec!["release-v1".to_string()],
+            vec!["feature".to_string()],
+        )
+    );
+    assert!(repo.cached_diff().is_empty());
+    let merge_base = repo.git_stdout(&["merge-base", "origin/release-v1", "origin/feature"]);
+    assert_eq!(
+        repo.worktree_diff(),
+        repo.diff(&merge_base, "origin/feature")
+    );
+    assert!(!repo.path().join("pair-one.txt").exists());
+    assert_eq!(repo.read_file("pair-two.txt"), "second pair\n");
+}
+
+#[test]
+fn test_review_leaves_legacy_branch_untouched_and_creates_metadata_backed_branch() {
+    let repo = TempGitRepo::new();
+
+    repo.create_branch("develop");
+    repo.write_file("develop.txt", "develop change\n");
+    repo.git(&["add", "."]);
+    repo.commit("Add develop change");
+    repo.git(&["push", "-u", "origin", "develop"]);
+
+    repo.switch_branch("main");
+    repo.create_branch("review-main-develop");
+    let legacy_oid = repo.rev_parse("HEAD");
+    assert_eq!(
+        repo.review_metadata_values("review-main-develop"),
+        (Vec::new(), Vec::new(), Vec::new())
+    );
+    repo.switch_branch("main");
+
+    let first = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        first.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&first.stdout),
+        String::from_utf8_lossy(&first.stderr)
+    );
+    let metadata_branch = repo.current_branch();
+    assert_identity_suffixed_branch(&metadata_branch, "review-main-develop");
+    assert_eq!(repo.rev_parse("refs/heads/review-main-develop"), legacy_oid);
+    assert_eq!(
+        repo.review_metadata_values("review-main-develop"),
+        (Vec::new(), Vec::new(), Vec::new())
+    );
+    assert_eq!(
+        repo.review_metadata_values(&metadata_branch),
+        (
+            vec!["1".to_string()],
+            vec!["main".to_string()],
+            vec!["develop".to_string()],
+        )
+    );
+    assert!(repo.cached_diff().is_empty());
+    let merge_base = repo.git_stdout(&["merge-base", "origin/main", "origin/develop"]);
+    assert_eq!(
+        repo.worktree_diff(),
+        repo.diff(&merge_base, "origin/develop")
+    );
+
+    assert!(repo.run_cresca(&["approve"]).status.success());
+    repo.switch_branch("main");
+    let heads_before = repo
+        .git(&[
+            "for-each-ref",
+            "--sort=refname",
+            "--format=%(refname) %(objectname)",
+            "refs/heads/",
+        ])
+        .stdout;
+
+    let second = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        second.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&second.stdout),
+        String::from_utf8_lossy(&second.stderr)
+    );
+    assert_eq!(repo.current_branch(), metadata_branch);
+    assert_eq!(
+        repo.git(&[
+            "for-each-ref",
+            "--sort=refname",
+            "--format=%(refname) %(objectname)",
+            "refs/heads/",
+        ])
+        .stdout,
+        heads_before
+    );
+}
+
+#[test]
+fn test_review_fails_atomically_when_base_and_identity_suffix_belong_to_other_reviews() {
+    let repo = TempGitRepo::new();
+
+    repo.create_branch("develop");
+    repo.write_file("develop.txt", "develop change\n");
+    repo.git(&["add", "."]);
+    repo.commit("Add develop change");
+    repo.git(&["push", "-u", "origin", "develop"]);
+
+    repo.switch_branch("main");
+    repo.create_branch("review-main-develop");
+    repo.switch_branch("main");
+
+    let first = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        first.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&first.stdout),
+        String::from_utf8_lossy(&first.stderr)
+    );
+    let suffixed_branch = repo.current_branch();
+    assert_identity_suffixed_branch(&suffixed_branch, "review-main-develop");
+    assert!(repo.run_cresca(&["approve"]).status.success());
+
+    repo.git(&[
+        "config",
+        "--local",
+        &format!("branch.{suffixed_branch}.cresca-target"),
+        "other-target",
+    ]);
+    repo.git(&[
+        "config",
+        "--local",
+        &format!("branch.{suffixed_branch}.cresca-source"),
+        "other-source",
+    ]);
+    assert_eq!(
+        repo.git_config_values(&format!("branch.{suffixed_branch}.cresca-version")),
+        vec!["1".to_string()]
+    );
+
+    repo.switch_branch("main");
+    let before = repo.snapshot();
+    let output = repo.run_cresca(&["review", "main", "develop"]);
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("conflicting review branches")
+            && stderr.contains("review-main-develop")
+            && stderr.contains(&suffixed_branch),
+        "expected conflicting review branch diagnostic, got: {stderr}"
+    );
+    assert_eq!(repo.snapshot(), before);
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -876,6 +876,57 @@ fn test_review_with_stop_at_before_skip_to() {
     assert!(!repo.ref_exists("refs/heads/review-main-develop"));
 }
 
+/// Test that `cresca review` records the exact CLI target and source values.
+#[test]
+fn test_review_records_versioned_target_and_source_metadata() {
+    let repo = TempGitRepo::new();
+
+    repo.create_branch("release-v1");
+    repo.write_file("release.txt", "release base\n");
+    repo.git(&["add", "."]);
+    repo.commit("Add release base");
+    repo.git(&["push", "-u", "origin", "release-v1"]);
+
+    repo.create_branch("feature/login-page");
+    repo.write_file("login.txt", "login page\n");
+    repo.git(&["add", "."]);
+    repo.commit("Add login page");
+    repo.git(&["push", "-u", "origin", "feature/login-page"]);
+    repo.switch_branch("main");
+
+    let output = repo.run_cresca(&["review", "release-v1", "feature/login-page"]);
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        repo.current_branch(),
+        "review-release-v1-feature_login-page"
+    );
+    assert_eq!(
+        repo.review_metadata_values("review-release-v1-feature_login-page"),
+        (
+            vec!["1".to_string()],
+            vec!["release-v1".to_string()],
+            vec!["feature/login-page".to_string()],
+        )
+    );
+    assert!(repo.cached_diff().is_empty());
+    assert_eq!(
+        repo.worktree_diff(),
+        repo.diff(
+            &repo.git_stdout(&[
+                "merge-base",
+                "origin/release-v1",
+                "origin/feature/login-page",
+            ]),
+            "origin/feature/login-page",
+        )
+    );
+}
+
 /// Test that `cresca review` works with branch names containing slashes.
 #[test]
 fn test_review_with_slash_in_branch_name() {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -549,6 +549,10 @@ fn test_failed_review_preparation_does_not_commit_review_metadata() {
             repo.path().join("missing-global-gitconfig"),
         )
         .env("GIT_CONFIG_NOSYSTEM", "1")
+        // GIT_CONFIG_COUNT is the authority for indexed KEY/VALUE pairs; without
+        // it, inherited GIT_CONFIG_KEY_n/GIT_CONFIG_VALUE_n entries are ignored.
+        .env_remove("GIT_CONFIG_COUNT")
+        .env_remove("GIT_CONFIG_PARAMETERS")
         .env_remove("GIT_AUTHOR_NAME")
         .env_remove("GIT_AUTHOR_EMAIL")
         .env_remove("GIT_COMMITTER_NAME")

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -88,14 +88,13 @@ fn prepare_staged_unstaged_and_untracked_changes(repo: &TempGitRepo) {
     repo.write_file("untracked.txt", "untracked content\n");
 }
 
-fn assert_invalid_review_branch_rejection(output: &std::process::Output) {
+fn assert_invalid_review_command_preserves_state(repo: &TempGitRepo, args: &[&str]) {
+    let before = repo.snapshot();
+    let output = repo.run_cresca(args);
     assert!(!output.status.success());
     assert!(output.stdout.is_empty());
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("valid cresca review branch") && stderr.contains("cresca review"),
-        "expected invalid review metadata diagnostic, got: {stderr}"
-    );
+    assert!(String::from_utf8_lossy(&output.stderr).contains("valid cresca review branch"));
+    assert_eq!(repo.snapshot(), before);
 }
 
 #[test]
@@ -338,12 +337,7 @@ fn test_approve_with_no_staged_changes_approves_nothing() {
 fn test_approve_on_non_review_branch() {
     let repo = TempGitRepo::new();
     prepare_staged_unstaged_and_untracked_changes(&repo);
-    let before = repo.snapshot();
-
-    let output = repo.run_cresca(&["approve"]);
-
-    assert_invalid_review_branch_rejection(&output);
-    assert_eq!(repo.snapshot(), before);
+    assert_invalid_review_command_preserves_state(&repo, &["approve"]);
 }
 
 #[test]
@@ -351,12 +345,7 @@ fn test_approve_rejects_review_prefixed_branch_without_metadata_and_preserves_st
     let repo = TempGitRepo::new();
     repo.create_branch("review-not-created-by-cresca");
     prepare_staged_unstaged_and_untracked_changes(&repo);
-    let before = repo.snapshot();
-
-    let output = repo.run_cresca(&["approve"]);
-
-    assert_invalid_review_branch_rejection(&output);
-    assert_eq!(repo.snapshot(), before);
+    assert_invalid_review_command_preserves_state(&repo, &["approve"]);
 }
 
 #[test]
@@ -382,12 +371,7 @@ fn test_approve_rejects_unsupported_review_metadata_and_preserves_state() {
         "999",
     ]);
     prepare_staged_unstaged_and_untracked_changes(&repo);
-    let before = repo.snapshot();
-
-    let output = repo.run_cresca(&["approve"]);
-
-    assert_invalid_review_branch_rejection(&output);
-    assert_eq!(repo.snapshot(), before);
+    assert_invalid_review_command_preserves_state(&repo, &["approve"]);
 }
 
 #[test]
@@ -397,12 +381,7 @@ fn test_approve_rejects_non_review_name_even_with_valid_metadata() {
     repo.git(&["config", "--local", "branch.main.cresca-target", "main"]);
     repo.git(&["config", "--local", "branch.main.cresca-source", "develop"]);
     prepare_staged_unstaged_and_untracked_changes(&repo);
-    let before = repo.snapshot();
-
-    let output = repo.run_cresca(&["approve"]);
-
-    assert_invalid_review_branch_rejection(&output);
-    assert_eq!(repo.snapshot(), before);
+    assert_invalid_review_command_preserves_state(&repo, &["approve"]);
 }
 
 /// Test that `cresca review` fails with uncommitted changes.
@@ -669,12 +648,7 @@ fn test_status_shows_diff_stats() {
 fn test_status_on_non_review_branch() {
     let repo = TempGitRepo::new();
     prepare_staged_unstaged_and_untracked_changes(&repo);
-    let before = repo.snapshot();
-
-    let output = repo.run_cresca(&["status"]);
-
-    assert_invalid_review_branch_rejection(&output);
-    assert_eq!(repo.snapshot(), before);
+    assert_invalid_review_command_preserves_state(&repo, &["status"]);
 }
 
 #[test]
@@ -688,12 +662,7 @@ fn test_status_rejects_parseable_legacy_branch_without_metadata_and_preserves_st
     repo.switch_branch("main");
     repo.create_branch("review-main-develop");
     prepare_staged_unstaged_and_untracked_changes(&repo);
-    let before = repo.snapshot();
-
-    let output = repo.run_cresca(&["status"]);
-
-    assert_invalid_review_branch_rejection(&output);
-    assert_eq!(repo.snapshot(), before);
+    assert_invalid_review_command_preserves_state(&repo, &["status"]);
 }
 
 #[test]
@@ -732,12 +701,7 @@ fn test_status_rejects_duplicate_review_metadata_and_preserves_state() {
         "branch.review-main-develop.cresca-source",
         "other-develop",
     ]);
-    let before = repo.snapshot();
-
-    let output = repo.run_cresca(&["status"]);
-
-    assert_invalid_review_branch_rejection(&output);
-    assert_eq!(repo.snapshot(), before);
+    assert_invalid_review_command_preserves_state(&repo, &["status"]);
 }
 
 /// Test that `cresca status` updates after partial approval.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -548,6 +548,12 @@ fn test_failed_review_preparation_does_not_commit_review_metadata() {
             "GIT_CONFIG_GLOBAL",
             repo.path().join("missing-global-gitconfig"),
         )
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env_remove("GIT_AUTHOR_NAME")
+        .env_remove("GIT_AUTHOR_EMAIL")
+        .env_remove("GIT_COMMITTER_NAME")
+        .env_remove("GIT_COMMITTER_EMAIL")
+        .env_remove("EMAIL")
         .current_dir(repo.path())
         .output()
         .expect("Failed to execute cresca");

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -75,6 +75,16 @@ fn prepare_staged_unstaged_and_untracked_changes(repo: &TempGitRepo) {
     repo.write_file("untracked.txt", "untracked content\n");
 }
 
+fn assert_invalid_review_branch_rejection(output: &std::process::Output) {
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("valid cresca review branch") && stderr.contains("cresca review"),
+        "expected invalid review metadata diagnostic, got: {stderr}"
+    );
+}
+
 #[test]
 fn test_helpers_capture_untracked_and_do_not_mutate_real_index() {
     let repo = TempGitRepo::new();
@@ -319,16 +329,66 @@ fn test_approve_on_non_review_branch() {
 
     let output = repo.run_cresca(&["approve"]);
 
-    assert!(
-        !output.status.success(),
-        "cresca approve should fail on non-review branch"
-    );
+    assert_invalid_review_branch_rejection(&output);
+    assert_eq!(repo.snapshot(), before);
+}
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("Not on a review branch"),
-        "expected non-review diagnostic, got: {stderr}"
-    );
+#[test]
+fn test_approve_rejects_review_prefixed_branch_without_metadata_and_preserves_state() {
+    let repo = TempGitRepo::new();
+    repo.create_branch("review-not-created-by-cresca");
+    prepare_staged_unstaged_and_untracked_changes(&repo);
+    let before = repo.snapshot();
+
+    let output = repo.run_cresca(&["approve"]);
+
+    assert_invalid_review_branch_rejection(&output);
+    assert_eq!(repo.snapshot(), before);
+}
+
+#[test]
+fn test_approve_rejects_unsupported_review_metadata_and_preserves_state() {
+    let repo = TempGitRepo::new();
+    repo.create_branch("review-corrupt");
+    repo.git(&[
+        "config",
+        "--local",
+        "branch.review-corrupt.cresca-target",
+        "main",
+    ]);
+    repo.git(&[
+        "config",
+        "--local",
+        "branch.review-corrupt.cresca-source",
+        "develop",
+    ]);
+    repo.git(&[
+        "config",
+        "--local",
+        "branch.review-corrupt.cresca-version",
+        "999",
+    ]);
+    prepare_staged_unstaged_and_untracked_changes(&repo);
+    let before = repo.snapshot();
+
+    let output = repo.run_cresca(&["approve"]);
+
+    assert_invalid_review_branch_rejection(&output);
+    assert_eq!(repo.snapshot(), before);
+}
+
+#[test]
+fn test_approve_rejects_non_review_name_even_with_valid_metadata() {
+    let repo = TempGitRepo::new();
+    repo.git(&["config", "--local", "branch.main.cresca-version", "1"]);
+    repo.git(&["config", "--local", "branch.main.cresca-target", "main"]);
+    repo.git(&["config", "--local", "branch.main.cresca-source", "develop"]);
+    prepare_staged_unstaged_and_untracked_changes(&repo);
+    let before = repo.snapshot();
+
+    let output = repo.run_cresca(&["approve"]);
+
+    assert_invalid_review_branch_rejection(&output);
     assert_eq!(repo.snapshot(), before);
 }
 
@@ -554,16 +614,70 @@ fn test_status_on_non_review_branch() {
 
     let output = repo.run_cresca(&["status"]);
 
-    assert!(
-        !output.status.success(),
-        "cresca status should fail on non-review branch"
-    );
+    assert_invalid_review_branch_rejection(&output);
+    assert_eq!(repo.snapshot(), before);
+}
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("Not on a review branch"),
-        "expected non-review diagnostic, got: {stderr}"
-    );
+#[test]
+fn test_status_rejects_parseable_legacy_branch_without_metadata_and_preserves_state() {
+    let repo = TempGitRepo::new();
+    repo.create_branch("develop");
+    repo.write_file("develop.txt", "develop content\n");
+    repo.git(&["add", "."]);
+    repo.commit("Add develop content");
+    repo.git(&["push", "-u", "origin", "develop"]);
+    repo.switch_branch("main");
+    repo.create_branch("review-main-develop");
+    prepare_staged_unstaged_and_untracked_changes(&repo);
+    let before = repo.snapshot();
+
+    let output = repo.run_cresca(&["status"]);
+
+    assert_invalid_review_branch_rejection(&output);
+    assert_eq!(repo.snapshot(), before);
+}
+
+#[test]
+fn test_status_rejects_duplicate_review_metadata_and_preserves_state() {
+    let repo = TempGitRepo::new();
+    repo.create_branch("develop");
+    repo.write_file("develop.txt", "develop content\n");
+    repo.git(&["add", "."]);
+    repo.commit("Add develop content");
+    repo.git(&["push", "-u", "origin", "develop"]);
+    repo.switch_branch("main");
+    repo.create_branch("review-main-develop");
+    repo.git(&[
+        "config",
+        "--local",
+        "branch.review-main-develop.cresca-version",
+        "1",
+    ]);
+    repo.git(&[
+        "config",
+        "--local",
+        "branch.review-main-develop.cresca-target",
+        "main",
+    ]);
+    repo.git(&[
+        "config",
+        "--local",
+        "--add",
+        "branch.review-main-develop.cresca-source",
+        "develop",
+    ]);
+    repo.git(&[
+        "config",
+        "--local",
+        "--add",
+        "branch.review-main-develop.cresca-source",
+        "other-develop",
+    ]);
+    let before = repo.snapshot();
+
+    let output = repo.run_cresca(&["status"]);
+
+    assert_invalid_review_branch_rejection(&output);
     assert_eq!(repo.snapshot(), before);
 }
 
@@ -925,6 +1039,46 @@ fn test_review_records_versioned_target_and_source_metadata() {
             "origin/feature/login-page",
         )
     );
+}
+
+#[test]
+fn test_status_uses_metadata_for_hyphenated_target_and_slash_source() {
+    let repo = TempGitRepo::new();
+
+    repo.create_branch("release-v1");
+    repo.write_file("release.txt", "release base\n");
+    repo.git(&["add", "."]);
+    repo.commit("Add release base");
+    repo.git(&["push", "-u", "origin", "release-v1"]);
+
+    repo.create_branch("feature/login-page");
+    repo.write_file("login.txt", "login page\n");
+    repo.git(&["add", "."]);
+    repo.commit("Add login page");
+    repo.git(&["push", "-u", "origin", "feature/login-page"]);
+    repo.switch_branch("main");
+
+    let review_output = repo.run_cresca(&["review", "release-v1", "feature/login-page"]);
+    assert!(
+        review_output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&review_output.stdout),
+        String::from_utf8_lossy(&review_output.stderr)
+    );
+
+    let output = repo.run_cresca(&["status"]);
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Remaining diff to feature/login-page:"));
+    assert!(stdout.contains("1 file(s), +1 insertion(s), -0 deletion(s)"));
+    assert!(stdout.contains("    - login.txt\n"));
+    assert!(output.stderr.is_empty());
 }
 
 /// Test that `cresca review` works with branch names containing slashes.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1091,7 +1091,165 @@ fn test_review_records_versioned_target_and_source_metadata() {
 }
 
 #[test]
-fn test_review_stops_when_existing_metadata_version_cannot_be_cleared() {
+fn test_review_treats_orphan_base_metadata_as_occupied() {
+    let repo = TempGitRepo::new();
+
+    repo.create_branch("develop");
+    repo.write_file("develop.txt", "develop change\n");
+    repo.git(&["add", "."]);
+    repo.commit("Add develop change");
+    repo.git(&["push", "-u", "origin", "develop"]);
+    repo.switch_branch("main");
+
+    let base = "review-main-develop";
+    repo.git(&[
+        "config",
+        "--local",
+        &format!("branch.{base}.cresca-version"),
+        "1",
+    ]);
+    repo.git(&[
+        "config",
+        "--local",
+        &format!("branch.{base}.cresca-target"),
+        "other-target",
+    ]);
+    repo.git(&[
+        "config",
+        "--local",
+        &format!("branch.{base}.cresca-source"),
+        "other-source",
+    ]);
+    let orphan_metadata = repo.review_metadata_values(base);
+
+    let output = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let suffix = "review-main-develop-5ee67b20f1cad176";
+    assert_eq!(repo.current_branch(), suffix);
+    assert!(!repo.ref_exists(&format!("refs/heads/{base}")));
+    assert_eq!(repo.review_metadata_values(base), orphan_metadata);
+    assert_eq!(
+        repo.review_metadata_values(suffix),
+        (
+            vec!["1".to_string()],
+            vec!["main".to_string()],
+            vec!["develop".to_string()],
+        )
+    );
+    assert!(repo.cached_diff().is_empty());
+    let merge_base = repo.git_stdout(&["merge-base", "origin/main", "origin/develop"]);
+    assert_eq!(
+        repo.worktree_diff(),
+        repo.diff(&merge_base, "origin/develop")
+    );
+}
+
+#[test]
+fn test_review_fails_closed_when_orphan_metadata_occupies_suffix() {
+    let repo = TempGitRepo::new();
+
+    repo.create_branch("develop");
+    repo.write_file("develop.txt", "develop change\n");
+    repo.git(&["add", "."]);
+    repo.commit("Add develop change");
+    repo.git(&["push", "-u", "origin", "develop"]);
+    repo.switch_branch("main");
+
+    let base = "review-main-develop";
+    repo.create_branch(base);
+    repo.switch_branch("main");
+    let suffix = "review-main-develop-5ee67b20f1cad176";
+    repo.git(&[
+        "config",
+        "--local",
+        &format!("branch.{suffix}.cresca-source"),
+        "orphan-source",
+    ]);
+    let before = repo.snapshot();
+
+    let output = repo.run_cresca(&["review", "main", "develop"]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("conflicting review branches")
+            && stderr.contains(base)
+            && stderr.contains(suffix),
+        "expected orphan suffix conflict diagnostic, got: {stderr}"
+    );
+    assert_eq!(repo.snapshot(), before);
+    assert!(!repo.ref_exists(&format!("refs/heads/{suffix}")));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_review_fails_closed_when_metadata_config_read_fails() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let repo = TempGitRepo::new();
+
+    repo.create_branch("develop");
+    repo.write_file("develop.txt", "develop change\n");
+    repo.git(&["add", "."]);
+    repo.commit("Add develop change");
+    repo.git(&["push", "-u", "origin", "develop"]);
+    repo.switch_branch("main");
+    repo.create_branch("review-main-develop");
+    repo.switch_branch("main");
+    let before = repo.snapshot();
+
+    let git_path = String::from_utf8(
+        std::process::Command::new("sh")
+            .args(["-c", "command -v git"])
+            .output()
+            .expect("git path lookup should execute")
+            .stdout,
+    )
+    .expect("git path should be UTF-8")
+    .trim()
+    .to_string();
+    let shim_dir = tempfile::TempDir::new().expect("git shim directory should be created");
+    let shim_path = shim_dir.path().join("git");
+    let shim = format!(
+        "#!/bin/sh\nif [ \"$1\" = config ] && [ \"$2\" = --local ] && [ \"$3\" = --get-all ] && [ \"$4\" = branch.review-main-develop.cresca-version ]; then\n  echo injected metadata read failure >&2\n  exit 2\nfi\nexec '{git_path}' \"$@\"\n"
+    );
+    std::fs::write(&shim_path, shim).expect("git shim should be writable");
+    let mut permissions = std::fs::metadata(&shim_path)
+        .expect("git shim metadata should be readable")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&shim_path, permissions).expect("git shim should be executable");
+    let path = std::env::join_paths(std::iter::once(shim_dir.path().to_path_buf()).chain(
+        std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default()),
+    ))
+    .expect("git shim PATH should be valid");
+
+    let output = std::process::Command::new(TempGitRepo::cresca_binary())
+        .args(["review", "main", "develop"])
+        .env("NO_COLOR", "1")
+        .env("PATH", path)
+        .current_dir(repo.path())
+        .output()
+        .expect("cresca should execute with git shim");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Failed to read review metadata")
+            && stderr.contains("injected metadata read failure"),
+        "expected strict metadata read failure, got: {stderr}"
+    );
+    assert_eq!(repo.snapshot(), before);
+}
+
+#[test]
+fn test_review_does_not_materialize_orphan_metadata_when_config_write_fails() {
     let repo = TempGitRepo::new();
 
     repo.create_branch("develop");
@@ -1121,6 +1279,7 @@ fn test_review_stops_when_existing_metadata_version_cannot_be_cleared() {
         "develop",
     ]);
     let metadata_before = repo.review_metadata_values(review_branch);
+    assert!(!repo.ref_exists(&format!("refs/heads/{review_branch}")));
 
     let config_lock_path = repo.path().join(".git/config.lock");
     std::fs::write(&config_lock_path, "lock metadata writes")
@@ -1133,20 +1292,23 @@ fn test_review_stops_when_existing_metadata_version_cannot_be_cleared() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("Failed to clear review metadata version marker"),
-        "expected version-clear failure, got: {stderr}"
+        stderr.contains("Failed to record review target"),
+        "expected metadata write failure, got: {stderr}"
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains(&format!(
-        "git config --local --unset-all branch.{review_branch}.cresca-version"
-    )));
     assert!(
-        !stdout.contains(&format!(
-            "git config --local --replace-all branch.{review_branch}.cresca-target"
-        )),
-        "metadata writes must stop after the version marker cannot be cleared: {stdout}"
+        !stdout.contains(&format!("git checkout -b {review_branch} ")),
+        "orphan metadata must prevent the base branch from being created: {stdout}"
     );
+    assert!(!repo.ref_exists(&format!("refs/heads/{review_branch}")));
     assert_eq!(repo.review_metadata_values(review_branch), metadata_before);
+
+    let suffix = "review-main-develop-5ee67b20f1cad176";
+    assert_eq!(
+        repo.review_metadata_values(suffix),
+        (Vec::new(), Vec::new(), Vec::new()),
+        "a failed write must not leave a valid review identity on the new branch"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Review branches are now identified by versioned local Git metadata instead of parsing the `review-` prefix and splitting branch names. This prevents ordinary prefixed branches from being accepted by `approve` or `status`, handles hyphenated and slash-containing refs without ambiguity, and avoids sanitized-name collisions through metadata-equality selection with a deterministic suffix.

Metadata is written version-last so incomplete records never become valid identities. Metadata read failures fail closed, orphaned configuration is treated as occupied, and failed branch materialization cannot leave a branch carrying the wrong valid identity. Legacy review branches without metadata are left untouched and rejected safely rather than guessed.

Coverage includes one unit test and 41 integration tests; `cargo fmt --all -- --check`, strict Clippy, and the full all-target/all-feature test suite pass.

Range-aware `status`/`--all` behavior and target-update reconstruction remain intentionally out of scope for follow-up work. Distinguishing exceptional nonzero `show-ref` failures from an ordinary missing ref is also a known non-blocking follow-up.