### PR TITLE
feat(status): distinguish current range from full pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ cresca review main develop --stop-at=C
 
 Use `git log --oneline main..develop` to see available commits.
 
+### Checking Review Progress
+
+`status` shows the changes that remain unapproved in the range prepared by the most recent successful `review` command:
+
+```sh
+cresca status
+```
+
+Use `--all` to include unapproved changes after that range and show the remaining diff across the full pull request:
+
+```sh
+cresca status --all
+```
+
 ## License
 
 [MIT](https://github.com/Lfu001/cresca/blob/main/LICENSE)

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,6 +1,6 @@
 use crate::git::{
     resolve_remote_tracking_branch, run_git_command, select_review_branch, write_review_metadata,
-    ReviewBranchSelection, ReviewMetadata,
+    write_review_scope, ReviewBranchSelection, ReviewMetadata, ReviewScope,
 };
 use colored::Colorize;
 use std::ops::Not;
@@ -130,6 +130,20 @@ pub fn prepare_review_branch(
         }
     }
 
+    let scope_end_revision = stop_at.unwrap_or(&tracking_from);
+    let scope_end_commit = format!("{scope_end_revision}^{{commit}}");
+    let scope_end_output = run_git_command(
+        "resolve review range endpoint",
+        &["rev-parse", "--verify", &scope_end_commit],
+        false,
+        verbose,
+    );
+    let scope = ReviewScope {
+        end_oid: String::from_utf8_lossy(&scope_end_output.stdout)
+            .trim()
+            .to_string(),
+    };
+
     let (review_branch, is_new) = match select_review_branch(&metadata, verbose) {
         ReviewBranchSelection::Existing(name) => {
             run_git_command(
@@ -151,8 +165,7 @@ pub fn prepare_review_branch(
         }
     };
 
-    // Determine target commit for squash merge
-    let target_commit = if let Some(hash) = skip_to {
+    if let Some(hash) = skip_to {
         // Auto-approve commits before skip_to by squash merging them
         let parent = format!("{}^", hash);
 
@@ -187,13 +200,9 @@ pub fn prepare_review_branch(
                 verbose,
             );
         }
+    }
 
-        // Use stop_at if specified, otherwise tracking_from
-        stop_at.unwrap_or(&tracking_from).to_string()
-    } else {
-        // Use stop_at if specified, otherwise tracking_from
-        stop_at.unwrap_or(&tracking_from).to_string()
-    };
+    let target_commit = scope.end_oid.clone();
 
     // Squash merge remaining changes
     run_git_command(
@@ -217,6 +226,7 @@ pub fn prepare_review_branch(
     if is_new {
         write_review_metadata(&review_branch, &metadata, verbose);
     }
+    write_review_scope(&review_branch, &scope, verbose);
 }
 
 /// Commit reviewed changes and discard unreviewed ones

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -276,7 +276,7 @@ pub fn approve_changes(verbose: bool) -> Result<(), ()> {
 
 /// Review status information
 pub struct ReviewStatus {
-    pub from_branch: String,
+    pub display_label: String,
     pub file_count: usize,
     pub insertions: usize,
     pub deletions: usize,
@@ -287,20 +287,18 @@ pub struct ReviewStatus {
 ///
 /// # Arguments
 ///
-/// * `from_branch` - The development branch to compare against.
+/// * `compare_ref` - The Git ref to compare against.
+/// * `display_label` - The human-readable label for the comparison.
 /// * `verbose` - Whether to print the git command and its output.
 ///
 /// # Returns
 ///
 /// * `ReviewStatus` - The remaining diff statistics
-pub fn get_review_status(from_branch: &str, verbose: bool) -> ReviewStatus {
-    let resolved_from = resolve_remote_tracking_branch(from_branch, verbose);
-    let tracking_from = resolved_from.tracking_ref;
-
+pub fn get_review_status(compare_ref: &str, display_label: &str, verbose: bool) -> ReviewStatus {
     // Get diff stats summary (use HEAD..branch for direct comparison, not HEAD...branch)
     let stat_output = run_git_command(
         "get diff stats",
-        &["diff", "--stat", "HEAD", &tracking_from],
+        &["diff", "--stat", "HEAD", compare_ref],
         false,
         verbose,
     );
@@ -333,7 +331,7 @@ pub fn get_review_status(from_branch: &str, verbose: bool) -> ReviewStatus {
     // Get list of changed files
     let files_output = run_git_command(
         "get changed files",
-        &["diff", "--name-only", "HEAD", &tracking_from],
+        &["diff", "--name-only", "HEAD", compare_ref],
         false,
         verbose,
     );
@@ -344,7 +342,7 @@ pub fn get_review_status(from_branch: &str, verbose: bool) -> ReviewStatus {
         .collect();
 
     ReviewStatus {
-        from_branch: from_branch.to_string(),
+        display_label: display_label.to_string(),
         file_count,
         insertions,
         deletions,

--- a/src/git.rs
+++ b/src/git.rs
@@ -25,7 +25,11 @@ pub enum ReviewMetadataError {
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum ReviewScopeError {
-    MissingOrInvalid,
+    Missing,
+    Duplicate,
+    UnsupportedVersion(String),
+    Invalid,
+    UnavailableCommit(String),
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -224,14 +228,36 @@ pub fn write_review_scope(branch: &str, scope: &ReviewScope, verbose: bool) {
 
 pub fn read_review_scope(branch: &str, verbose: bool) -> Result<ReviewScope, ReviewScopeError> {
     let values = review_config_values(branch, "scope", verbose);
-    let [value] = values.as_slice() else {
-        return Err(ReviewScopeError::MissingOrInvalid);
+    let value = match values.as_slice() {
+        [] => return Err(ReviewScopeError::Missing),
+        [value] => value,
+        _ => return Err(ReviewScopeError::Duplicate),
     };
     let Some((version, end_oid)) = value.split_once(':') else {
-        return Err(ReviewScopeError::MissingOrInvalid);
+        return Err(ReviewScopeError::Invalid);
     };
-    if version != REVIEW_SCOPE_VERSION || end_oid.is_empty() {
-        return Err(ReviewScopeError::MissingOrInvalid);
+    if version != REVIEW_SCOPE_VERSION {
+        return Err(ReviewScopeError::UnsupportedVersion(version.to_string()));
+    }
+    if end_oid.is_empty()
+        || end_oid.contains(':')
+        || !end_oid.bytes().all(|byte| byte.is_ascii_hexdigit())
+    {
+        return Err(ReviewScopeError::Invalid);
+    }
+    let revision = format!("{end_oid}^{{commit}}");
+    let output = run_git_command(
+        "validate review range endpoint",
+        &["rev-parse", "--verify", &revision],
+        true,
+        verbose,
+    );
+    if !output.status.success() {
+        return Err(ReviewScopeError::UnavailableCommit(end_oid.to_string()));
+    }
+    let canonical = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if canonical != end_oid {
+        return Err(ReviewScopeError::Invalid);
     }
     Ok(ReviewScope {
         end_oid: end_oid.to_string(),

--- a/src/git.rs
+++ b/src/git.rs
@@ -2,11 +2,17 @@ use colored::Colorize;
 use std::process::{exit, Command, Output};
 
 pub const REVIEW_METADATA_VERSION: &str = "1";
+pub const REVIEW_SCOPE_VERSION: &str = "1";
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ReviewMetadata {
     pub target: String,
     pub source: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ReviewScope {
+    pub end_oid: String,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -195,6 +201,17 @@ pub fn write_review_metadata(branch: &str, metadata: &ReviewMetadata, verbose: b
             &version_key,
             REVIEW_METADATA_VERSION,
         ],
+        false,
+        verbose,
+    );
+}
+
+pub fn write_review_scope(branch: &str, scope: &ReviewScope, verbose: bool) {
+    let key = review_config_key(branch, "scope");
+    let value = format!("{}:{}", REVIEW_SCOPE_VERSION, scope.end_oid);
+    run_git_command(
+        "record review range",
+        &["config", "--local", "--replace-all", &key, &value],
         false,
         verbose,
     );

--- a/src/git.rs
+++ b/src/git.rs
@@ -24,6 +24,11 @@ pub enum ReviewMetadataError {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+pub enum ReviewScopeError {
+    MissingOrInvalid,
+}
+
+#[derive(Debug, PartialEq, Eq)]
 pub enum ReviewBranchSelection {
     New(String),
     Existing(String),
@@ -215,6 +220,22 @@ pub fn write_review_scope(branch: &str, scope: &ReviewScope, verbose: bool) {
         false,
         verbose,
     );
+}
+
+pub fn read_review_scope(branch: &str, verbose: bool) -> Result<ReviewScope, ReviewScopeError> {
+    let values = review_config_values(branch, "scope", verbose);
+    let [value] = values.as_slice() else {
+        return Err(ReviewScopeError::MissingOrInvalid);
+    };
+    let Some((version, end_oid)) = value.split_once(':') else {
+        return Err(ReviewScopeError::MissingOrInvalid);
+    };
+    if version != REVIEW_SCOPE_VERSION || end_oid.is_empty() {
+        return Err(ReviewScopeError::MissingOrInvalid);
+    }
+    Ok(ReviewScope {
+        end_oid: end_oid.to_string(),
+    })
 }
 
 /// Run a git command and return the output

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,10 +151,22 @@ fn main() {
     }
 }
 
-fn exit_invalid_review_scope(_: ReviewScopeError, metadata: &ReviewMetadata) -> ! {
+fn exit_invalid_review_scope(error: ReviewScopeError, metadata: &ReviewMetadata) -> ! {
+    let reason = match error {
+        ReviewScopeError::Missing => "range metadata is missing".to_string(),
+        ReviewScopeError::Duplicate => "range metadata has duplicate values".to_string(),
+        ReviewScopeError::UnsupportedVersion(version) => {
+            format!("range metadata version '{version}' is unsupported")
+        }
+        ReviewScopeError::Invalid => "range metadata is invalid".to_string(),
+        ReviewScopeError::UnavailableCommit(oid) => {
+            format!("saved range endpoint '{oid}' is unavailable")
+        }
+    };
     eprintln!(
-        "{}: Cannot show current review range because range metadata is missing or invalid. Rerun `cresca review {} {}` to record the range. `cresca status --all` is still available.",
+        "{}: Cannot show current review range because {}. Rerun `cresca review {} {}` to record the range. `cresca status --all` is still available.",
         "error".red().bold(),
+        reason,
         metadata.target,
         metadata.source
     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,10 @@ use clap::builder::styling::{AnsiColor, Effects};
 use clap::{builder::Styles, ArgAction, Args, Parser, Subcommand};
 use colored::Colorize;
 use commands::{approve_changes, get_review_status, prepare_review_branch};
-use git::{current_review_metadata, is_clean, ReviewMetadataError};
+use git::{
+    current_branch_name, current_review_metadata, is_clean, read_review_scope,
+    resolve_remote_tracking_branch, ReviewMetadata, ReviewMetadataError, ReviewScopeError,
+};
 use std::process::exit;
 
 const STYLES: Styles = Styles::styled()
@@ -43,7 +46,14 @@ enum Commands {
     /// Prepare a review branch.
     Review(ReviewArgs),
     /// Show remaining diff statistics.
-    Status,
+    Status(StatusArgs),
+}
+
+#[derive(Args)]
+struct StatusArgs {
+    /// Show unapproved changes across the full pull request.
+    #[arg(long)]
+    all: bool,
 }
 
 #[derive(Args)]
@@ -95,14 +105,31 @@ fn main() {
                 println!("Review branch prepared successfully. Stage the changes you have reviewed and run `{}` to approve them.", "cresca approve".green());
             }
         }
-        Commands::Status => {
+        Commands::Status(args) => {
             let metadata = current_review_metadata(cli.verbose)
                 .unwrap_or_else(|error| exit_invalid_review_branch(error));
-            let status = get_review_status(&metadata.source, cli.verbose);
-            println!("📋 Review status:");
+            let (heading, compare_ref, display_label) = if args.all {
+                let resolved = resolve_remote_tracking_branch(&metadata.source, cli.verbose);
+                (
+                    "full pull request",
+                    resolved.tracking_ref,
+                    format!("to {}", metadata.source),
+                )
+            } else {
+                let branch = current_branch_name(cli.verbose);
+                let scope = read_review_scope(&branch, cli.verbose)
+                    .unwrap_or_else(|error| exit_invalid_review_scope(error, &metadata));
+                (
+                    "current range",
+                    scope.end_oid,
+                    "in current review range".to_string(),
+                )
+            };
+            let status = get_review_status(&compare_ref, &display_label, cli.verbose);
+            println!("📋 Review status ({}):", heading);
             println!(
-                "  Remaining diff to {}: {} file(s), {} insertion(s), {} deletion(s)",
-                status.from_branch.green(),
+                "  Remaining diff {}: {} file(s), {} insertion(s), {} deletion(s)",
+                status.display_label,
                 status.file_count.to_string().yellow(),
                 format!("+{}", status.insertions).green(),
                 format!("-{}", status.deletions).red()
@@ -122,6 +149,16 @@ fn main() {
             }
         }
     }
+}
+
+fn exit_invalid_review_scope(_: ReviewScopeError, metadata: &ReviewMetadata) -> ! {
+    eprintln!(
+        "{}: Cannot show current review range because range metadata is missing or invalid. Rerun `cresca review {} {}` to record the range. `cresca status --all` is still available.",
+        "error".red().bold(),
+        metadata.target,
+        metadata.source
+    );
+    exit(1);
 }
 
 fn exit_invalid_review_branch(_: ReviewMetadataError) -> ! {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -115,6 +115,10 @@ impl TempGitRepo {
         )
     }
 
+    pub fn review_scope_values(&self, branch: &str) -> Vec<String> {
+        self.git_config_values(&format!("branch.{branch}.cresca-scope"))
+    }
+
     /// Resolves a revision to its object ID.
     pub fn rev_parse(&self, revision: &str) -> String {
         self.git_stdout(&["rev-parse", revision])

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -55,6 +55,98 @@ fn setup_linear_range() -> (TempGitRepo, LinearRange) {
     (repo, LinearRange { base, a, b, c, d })
 }
 
+#[test]
+fn test_review_records_source_tip_as_full_scope_end_without_stop_at() {
+    let (repo, range) = setup_linear_range();
+    let output = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        repo.review_scope_values("review-main-develop"),
+        vec![format!("1:{}", range.d)]
+    );
+}
+
+#[test]
+fn test_review_records_stop_at_as_full_scope_end() {
+    let (repo, range) = setup_linear_range();
+    let output = repo.run_cresca(&["review", "main", "develop", "--stop-at", &range.c[..8]]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        repo.review_scope_values("review-main-develop"),
+        vec![format!("1:{}", range.c)]
+    );
+}
+
+#[test]
+fn test_review_scope_end_is_independent_of_skip_to() {
+    let (repo, range) = setup_linear_range();
+    let output = repo.run_cresca(&[
+        "review",
+        "main",
+        "develop",
+        "--skip-to",
+        &range.b[..8],
+        "--stop-at",
+        &range.c[..8],
+    ]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        repo.review_scope_values("review-main-develop"),
+        vec![format!("1:{}", range.c)]
+    );
+}
+
+#[test]
+fn test_successful_rereview_replaces_scope_end() {
+    let (repo, range) = setup_linear_range();
+    assert!(repo
+        .run_cresca(&["review", "main", "develop", "--stop-at", &range.c[..8],])
+        .status
+        .success());
+    repo.git(&["add", "-A"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+    let output = repo.run_cresca(&["review", "main", "develop", "--stop-at", &range.d[..8]]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        repo.review_scope_values("review-main-develop"),
+        vec![format!("1:{}", range.d)]
+    );
+}
+
+#[test]
+fn test_failed_rereview_preserves_previous_scope_end() {
+    let (repo, range) = setup_linear_range();
+    assert!(repo
+        .run_cresca(&["review", "main", "develop", "--stop-at", &range.c[..8],])
+        .status
+        .success());
+    repo.git(&["add", "-A"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+    let before = repo.review_scope_values("review-main-develop");
+    assert_eq!(before, vec![format!("1:{}", range.c)]);
+    let output = repo.run_cresca(&["review", "main", "develop", "--stop-at", "does-not-exist"]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("does-not-exist") && stderr.contains("is not in the range"));
+    assert_eq!(repo.review_scope_values("review-main-develop"), before);
+}
+
 fn assert_review_matches(
     repo: &TempGitRepo,
     expected_branch: &str,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1744,19 +1744,112 @@ fn test_status_uses_metadata_for_hyphenated_target_and_slash_source() {
     assert!(output.stderr.is_empty());
 }
 
-#[test]
-fn test_status_requires_recorded_range_while_all_uses_identity_only() {
-    let repo = setup_identity_only_review_branch();
+fn assert_scope_error_and_all_available(repo: &TempGitRepo, expected_error: &str) {
+    let before = repo.snapshot();
     let output = repo.run_cresca(&["status"]);
     assert!(!output.status.success());
     assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        String::from_utf8_lossy(&output.stderr).contains("range metadata is missing or invalid")
+        stderr.contains(expected_error),
+        "unexpected diagnostic: {stderr}"
     );
+    assert!(stderr.contains("cresca review main develop"));
+    assert!(stderr.contains("cresca status --all"));
+    assert_eq!(repo.snapshot(), before);
+
     let all = repo.run_cresca(&["status", "--all"]);
-    assert!(all.status.success());
+    assert!(
+        all.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&all.stdout),
+        String::from_utf8_lossy(&all.stderr)
+    );
     assert!(String::from_utf8_lossy(&all.stdout).contains("    - develop.txt\n"));
     assert!(all.stderr.is_empty());
+}
+
+#[test]
+fn test_status_requires_scope_metadata_but_all_works_for_pr12_identity() {
+    let repo = setup_identity_only_review_branch();
+    assert_scope_error_and_all_available(&repo, "range metadata is missing");
+}
+
+#[test]
+fn test_status_rejects_duplicate_scope_values_but_all_still_works() {
+    let repo = setup_identity_only_review_branch();
+    let value = format!("1:{}", repo.rev_parse("HEAD"));
+    repo.git(&[
+        "config",
+        "--local",
+        "--add",
+        "branch.review-main-develop.cresca-scope",
+        &value,
+    ]);
+    repo.git(&[
+        "config",
+        "--local",
+        "--add",
+        "branch.review-main-develop.cresca-scope",
+        &value,
+    ]);
+    assert_scope_error_and_all_available(&repo, "range metadata has duplicate values");
+}
+
+#[test]
+fn test_status_rejects_unsupported_scope_version_but_all_still_works() {
+    let repo = setup_identity_only_review_branch();
+    let value = format!("2:{}", repo.rev_parse("HEAD"));
+    repo.git(&[
+        "config",
+        "--local",
+        "branch.review-main-develop.cresca-scope",
+        &value,
+    ]);
+    assert_scope_error_and_all_available(&repo, "range metadata version '2' is unsupported");
+}
+
+#[test]
+fn test_status_rejects_malformed_scope_oid_but_all_still_works() {
+    let repo = setup_identity_only_review_branch();
+    repo.git(&[
+        "config",
+        "--local",
+        "branch.review-main-develop.cresca-scope",
+        "1:not-an-oid",
+    ]);
+    assert_scope_error_and_all_available(&repo, "range metadata is invalid");
+}
+
+#[test]
+fn test_status_rejects_abbreviated_scope_oid() {
+    let repo = setup_identity_only_review_branch();
+    let head = repo.rev_parse("HEAD");
+    let value = format!("1:{}", &head[..8]);
+    repo.git(&[
+        "config",
+        "--local",
+        "branch.review-main-develop.cresca-scope",
+        &value,
+    ]);
+    assert_scope_error_and_all_available(&repo, "range metadata is invalid");
+}
+
+#[test]
+fn test_status_rejects_unavailable_scope_commit_but_all_still_works() {
+    let repo = setup_identity_only_review_branch();
+    let oid = "0000000000000000000000000000000000000000";
+    let value = format!("1:{oid}");
+    repo.git(&[
+        "config",
+        "--local",
+        "branch.review-main-develop.cresca-scope",
+        &value,
+    ]);
+    assert_scope_error_and_all_available(
+        &repo,
+        &format!("saved range endpoint '{oid}' is unavailable"),
+    );
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -55,6 +55,49 @@ fn setup_linear_range() -> (TempGitRepo, LinearRange) {
     (repo, LinearRange { base, a, b, c, d })
 }
 
+fn run_status_stdout(repo: &TempGitRepo, args: &[&str]) -> String {
+    let output = repo.run_cresca(args);
+    assert!(
+        output.status.success(),
+        "cresca {} failed\nstdout: {}\nstderr: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty());
+    String::from_utf8(output.stdout).expect("status stdout should be UTF-8")
+}
+
+fn setup_identity_only_review_branch() -> TempGitRepo {
+    let repo = TempGitRepo::new();
+    repo.create_branch("develop");
+    repo.write_file("develop.txt", "develop content\n");
+    repo.git(&["add", "."]);
+    repo.commit("Add develop content");
+    repo.git(&["push", "-u", "origin", "develop"]);
+    repo.switch_branch("main");
+    repo.create_branch("review-main-develop");
+    repo.git(&[
+        "config",
+        "--local",
+        "branch.review-main-develop.cresca-version",
+        "1",
+    ]);
+    repo.git(&[
+        "config",
+        "--local",
+        "branch.review-main-develop.cresca-target",
+        "main",
+    ]);
+    repo.git(&[
+        "config",
+        "--local",
+        "branch.review-main-develop.cresca-source",
+        "develop",
+    ]);
+    repo
+}
+
 #[test]
 fn test_review_records_source_tip_as_full_scope_end_without_stop_at() {
     let (repo, range) = setup_linear_range();
@@ -735,8 +778,8 @@ fn test_status_shows_diff_stats() {
     assert_eq!(
         String::from_utf8(output.stdout).expect("status stdout should be UTF-8"),
         concat!(
-            "📋 Review status:\n",
-            "  Remaining diff to develop: 2 file(s), +3 insertion(s), -1 deletion(s)\n",
+            "📋 Review status (current range):\n",
+            "  Remaining diff in current review range: 2 file(s), +3 insertion(s), -1 deletion(s)\n",
             "  Files remaining:\n",
             "    - added.txt\n",
             "    - changed.txt\n",
@@ -851,8 +894,8 @@ fn test_status_after_partial_approval() {
     assert_eq!(
         String::from_utf8(output.stdout).expect("status stdout should be UTF-8"),
         concat!(
-            "📋 Review status:\n",
-            "  Remaining diff to develop: 1 file(s), +1 insertion(s), -1 deletion(s)\n",
+            "📋 Review status (current range):\n",
+            "  Remaining diff in current review range: 1 file(s), +1 insertion(s), -1 deletion(s)\n",
             "  Files remaining:\n",
             "    - changed.txt\n",
         )
@@ -885,8 +928,8 @@ fn test_status_after_partial_approval() {
     assert_eq!(
         String::from_utf8(output.stdout).expect("status stdout should be UTF-8"),
         concat!(
-            "📋 Review status:\n",
-            "  Remaining diff to develop: 0 file(s), +0 insertion(s), -0 deletion(s)\n",
+            "📋 Review status (current range):\n",
+            "  Remaining diff in current review range: 0 file(s), +0 insertion(s), -0 deletion(s)\n",
         )
     );
     assert!(output.stderr.is_empty());
@@ -1695,10 +1738,159 @@ fn test_status_uses_metadata_for_hyphenated_target_and_slash_source() {
         String::from_utf8_lossy(&output.stderr)
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("Remaining diff to feature/login-page:"));
+    assert!(stdout.contains("Remaining diff in current review range:"));
     assert!(stdout.contains("1 file(s), +1 insertion(s), -0 deletion(s)"));
     assert!(stdout.contains("    - login.txt\n"));
     assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn test_status_requires_recorded_range_while_all_uses_identity_only() {
+    let repo = setup_identity_only_review_branch();
+    let output = repo.run_cresca(&["status"]);
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("range metadata is missing or invalid")
+    );
+    let all = repo.run_cresca(&["status", "--all"]);
+    assert!(all.status.success());
+    assert!(String::from_utf8_lossy(&all.stdout).contains("    - develop.txt\n"));
+    assert!(all.stderr.is_empty());
+}
+
+#[test]
+fn test_status_keeps_unbounded_review_tip_fixed_until_next_review() {
+    let (repo, _) = setup_linear_range();
+    assert!(repo
+        .run_cresca(&["review", "main", "develop"])
+        .status
+        .success());
+    repo.git(&["add", "-A"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+    repo.switch_branch("develop");
+    repo.write_file("e.txt", "added at E\n");
+    repo.git(&["add", "e.txt"]);
+    repo.commit("E: add e.txt");
+    repo.git(&["push", "origin", "develop"]);
+    repo.switch_branch("review-main-develop");
+    assert_eq!(
+        run_status_stdout(&repo, &["status"]),
+        concat!(
+            "📋 Review status (current range):\n",
+            "  Remaining diff in current review range: 0 file(s), +0 insertion(s), -0 deletion(s)\n",
+        )
+    );
+    assert_eq!(
+        run_status_stdout(&repo, &["status", "--all"]),
+        concat!(
+            "📋 Review status (full pull request):\n",
+            "  Remaining diff to develop: 1 file(s), +1 insertion(s), -0 deletion(s)\n",
+            "  Files remaining:\n",
+            "    - e.txt\n",
+        )
+    );
+}
+
+#[test]
+fn test_status_default_excludes_commits_after_stop_at_while_all_includes_them() {
+    let (repo, range) = setup_linear_range();
+    assert!(repo
+        .run_cresca(&["review", "main", "develop", "--stop-at", &range.c[..8],])
+        .status
+        .success());
+    let current = run_status_stdout(&repo, &["status"]);
+    assert!(current.contains("📋 Review status (current range):"));
+    assert!(current.contains("3 file(s), +2 insertion(s), -2 deletion(s)"));
+    assert!(current.contains("    - a.txt\n"));
+    assert!(current.contains("    - removed-at-c.txt\n"));
+    assert!(current.contains("    - shared.txt\n"));
+    assert!(!current.contains("    - d.txt\n"));
+    let all = run_status_stdout(&repo, &["status", "--all"]);
+    assert!(all.contains("📋 Review status (full pull request):"));
+    assert!(all.contains("4 file(s), +3 insertion(s), -2 deletion(s)"));
+    for file in ["a.txt", "d.txt", "removed-at-c.txt", "shared.txt"] {
+        assert!(all.contains(&format!("    - {file}\n")));
+    }
+}
+
+#[test]
+fn test_status_after_skip_stop_and_partial_approve_excludes_auto_approved_changes() {
+    let (repo, range) = setup_linear_range();
+    assert!(repo
+        .run_cresca(&[
+            "review",
+            "main",
+            "develop",
+            "--skip-to",
+            &range.b[..8],
+            "--stop-at",
+            &range.c[..8],
+        ])
+        .status
+        .success());
+    repo.git(&["add", "shared.txt"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+    let current = run_status_stdout(&repo, &["status"]);
+    assert!(current.contains("1 file(s), +0 insertion(s), -1 deletion(s)"));
+    assert!(current.contains("    - removed-at-c.txt\n"));
+    assert!(!current.contains("a.txt"));
+    assert!(!current.contains("d.txt"));
+    let all = run_status_stdout(&repo, &["status", "--all"]);
+    assert!(all.contains("2 file(s), +1 insertion(s), -1 deletion(s)"));
+    assert!(all.contains("    - d.txt\n"));
+    assert!(all.contains("    - removed-at-c.txt\n"));
+    assert!(!all.contains("a.txt"));
+}
+
+#[test]
+fn test_status_current_range_can_be_complete_while_full_pull_request_remains() {
+    let (repo, range) = setup_linear_range();
+    assert!(repo
+        .run_cresca(&["review", "main", "develop", "--stop-at", &range.c[..8],])
+        .status
+        .success());
+    repo.git(&["add", "-A"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+    assert_eq!(
+        run_status_stdout(&repo, &["status"]),
+        concat!(
+            "📋 Review status (current range):\n",
+            "  Remaining diff in current review range: 0 file(s), +0 insertion(s), -0 deletion(s)\n",
+        )
+    );
+    assert_eq!(
+        run_status_stdout(&repo, &["status", "--all"]),
+        concat!(
+            "📋 Review status (full pull request):\n",
+            "  Remaining diff to develop: 1 file(s), +1 insertion(s), -0 deletion(s)\n",
+            "  Files remaining:\n",
+            "    - d.txt\n",
+        )
+    );
+}
+
+#[test]
+fn test_status_help_describes_all_scope() {
+    let repo = TempGitRepo::new();
+    let output = repo.run_cresca(&["status", "--help"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Usage: cresca status [OPTIONS]"));
+    assert!(stdout.contains("--all"));
+    assert!(stdout.contains("full pull request"));
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn test_status_rejects_unknown_option() {
+    let repo = TempGitRepo::new();
+    let before = repo.snapshot();
+    let output = repo.run_cresca(&["status", "--unknown"]);
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("unexpected argument '--unknown'"));
+    assert_eq!(repo.snapshot(), before);
 }
 
 /// Test that `cresca review` works with branch names containing slashes.


### PR DESCRIPTION
By default, `cresca status` now reports only unapproved changes in the most recent successfully prepared review range. The saved endpoint keeps later commits on the source branch from silently expanding the current review batch.

`cresca status --all` reports the remaining diff for the full pull request. If the saved range is missing or invalid, only the default command fails with guidance to rerun `cresca review`; `--all` remains available.