### PR TITLE
fix(review): roll back failed preparation exactly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.5.20", features = ["derive"] }
 colored = "2.1.0"
+tempfile = "3.24.0"
 
 [dev-dependencies]
 assert_cmd = "2.1.1"
 predicates = "3.1.3"
-tempfile = "3.24.0"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,7 +1,7 @@
 use crate::git::{
-    resolve_remote_tracking_branch, run_git_command, select_review_branch, write_review_metadata,
-    write_review_scope, ReviewBranchSelection, ReviewBranchSelectionError, ReviewMetadata,
-    ReviewScope,
+    is_clean, resolve_remote_tracking_branch, run_git_command, select_review_branch,
+    write_review_metadata, write_review_scope, ReviewBranchSelection, ReviewBranchSelectionError,
+    ReviewMetadata, ReviewScope,
 };
 use crate::review::{ReviewError, ReviewTransaction};
 use std::ops::Not;
@@ -21,8 +21,26 @@ pub fn prepare_review_branch(
     skip_to: Option<&str>,
     stop_at: Option<&str>,
     verbose: bool,
-) -> Result<(), ReviewError> {
+) -> Result<bool, ReviewError> {
     let mut transaction = ReviewTransaction::begin(verbose)?;
+    transaction
+        .execute(|| prepare_review_branch_inner(to_branch, from_branch, skip_to, stop_at, verbose))
+}
+
+fn prepare_review_branch_inner(
+    to_branch: &str,
+    from_branch: &str,
+    skip_to: Option<&str>,
+    stop_at: Option<&str>,
+    verbose: bool,
+) -> Result<bool, ReviewError> {
+    if !is_clean(verbose)? {
+        return Err(ReviewError::Message(
+            "Uncommitted changes found. Please commit or stash them before starting review."
+                .to_string(),
+        ));
+    }
+
     let metadata = ReviewMetadata {
         target: to_branch.to_string(),
         source: from_branch.to_string(),
@@ -152,58 +170,31 @@ pub fn prepare_review_branch(
         ReviewBranchSelectionError::Conflict(message) => ReviewError::Message(message),
     })?;
 
-    transaction.execute(|| {
-        let (review_branch, is_new) = match selection {
-            ReviewBranchSelection::Existing(name) => {
-                run_git_command(
-                    "switch to review branch",
-                    &["switch", &name],
-                    false,
-                    verbose,
-                )?;
-                (name, false)
-            }
-            ReviewBranchSelection::New(name) => {
-                run_git_command(
-                    "create review branch from merge-base",
-                    &["checkout", "-b", &name, &merge_base],
-                    false,
-                    verbose,
-                )?;
-                (name, true)
-            }
-        };
-
-        if let Some(parent) = auto_approve_parent {
-            // Auto-approve commits before skip_to by squash merging them
+    let (review_branch, is_new) = match selection {
+        ReviewBranchSelection::Existing(name) => {
             run_git_command(
-                "auto-approve earlier commits",
-                &[
-                    "merge",
-                    "--squash",
-                    "--ff",
-                    "--quiet",
-                    "--no-stat",
-                    "-X",
-                    "theirs",
-                    &parent,
-                ],
+                "switch to review branch",
+                &["switch", &name],
                 false,
                 verbose,
             )?;
-            run_git_command(
-                "commit auto-approved changes",
-                &["commit", "--quiet", "-m", "Auto-approve earlier commits"],
-                false,
-                verbose,
-            )?;
+            (name, false)
         }
+        ReviewBranchSelection::New(name) => {
+            run_git_command(
+                "create review branch from merge-base",
+                &["checkout", "-b", &name, &merge_base],
+                false,
+                verbose,
+            )?;
+            (name, true)
+        }
+    };
 
-        let target_commit = scope.end_oid.clone();
-
-        // Squash merge remaining changes
+    if let Some(parent) = auto_approve_parent {
+        // Auto-approve commits before skip_to by squash merging them
         run_git_command(
-            "squash merge remaining changes",
+            "auto-approve earlier commits",
             &[
                 "merge",
                 "--squash",
@@ -212,20 +203,45 @@ pub fn prepare_review_branch(
                 "--no-stat",
                 "-X",
                 "theirs",
-                &target_commit,
+                &parent,
             ],
             false,
             verbose,
         )?;
+        run_git_command(
+            "commit auto-approved changes",
+            &["commit", "--quiet", "-m", "Auto-approve earlier commits"],
+            false,
+            verbose,
+        )?;
+    }
 
-        // Unstage changes for review
-        run_git_command("unstage changes for review", &["reset"], false, verbose)?;
-        if is_new {
-            write_review_metadata(&review_branch, &metadata, verbose)?;
-        }
-        write_review_scope(&review_branch, &scope, verbose)?;
-        Ok(())
-    })
+    let target_commit = scope.end_oid.clone();
+
+    // Squash merge remaining changes
+    run_git_command(
+        "squash merge remaining changes",
+        &[
+            "merge",
+            "--squash",
+            "--ff",
+            "--quiet",
+            "--no-stat",
+            "-X",
+            "theirs",
+            &target_commit,
+        ],
+        false,
+        verbose,
+    )?;
+
+    // Unstage changes for review
+    run_git_command("unstage changes for review", &["reset"], false, verbose)?;
+    if is_new {
+        write_review_metadata(&review_branch, &metadata, verbose)?;
+    }
+    write_review_scope(&review_branch, &scope, verbose)?;
+    Ok(!is_clean(verbose)?)
 }
 
 /// Commit reviewed changes and discard unreviewed ones

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -12,6 +12,7 @@ struct ReviewPlan {
     auto_approve_parent: Option<String>,
     selection: ReviewBranchSelection,
     scope: ReviewScope,
+    tracking_updates: Vec<(String, String)>,
 }
 
 /// Prepare the review branch using Squash Merge approach.
@@ -30,9 +31,6 @@ pub fn prepare_review_branch(
     stop_at: Option<&str>,
     verbose: bool,
 ) -> Result<bool, ReviewError> {
-    // Review preparation never relies on the ambient temporary directory. In particular, Git
-    // launchers on some platforms create helper files there before Cresca can discover the repo.
-    std::env::set_var("TMPDIR", "/tmp");
     let root = ReviewTransaction::repository_root(verbose)?;
     std::env::set_current_dir(&root).map_err(|error| {
         ReviewError::Message(format!(
@@ -181,6 +179,16 @@ fn prepare_review_plan(
         ReviewBranchSelectionError::Git(error) => ReviewError::Git(error),
         ReviewBranchSelectionError::Conflict(message) => ReviewError::Message(message),
     })?;
+    let tracking_updates = vec![
+        (
+            format!("refs/remotes/{}", resolved_to.tracking_ref),
+            tracking_to,
+        ),
+        (
+            format!("refs/remotes/{}", resolved_from.tracking_ref),
+            tracking_from,
+        ),
+    ];
 
     Ok(ReviewPlan {
         metadata,
@@ -188,6 +196,7 @@ fn prepare_review_plan(
         auto_approve_parent,
         selection,
         scope,
+        tracking_updates,
     })
 }
 
@@ -220,6 +229,7 @@ fn fetch_remote_commit(
         &[
             "fetch",
             "--no-write-fetch-head",
+            "--no-tags",
             "--refmap=",
             remote,
             &remote_ref,
@@ -244,7 +254,17 @@ fn apply_review_plan(plan: ReviewPlan, verbose: bool) -> Result<bool, ReviewErro
         auto_approve_parent,
         selection,
         scope,
+        tracking_updates,
     } = plan;
+    for (number, (tracking_ref, oid)) in tracking_updates.iter().enumerate() {
+        let role = if number == 0 { "target" } else { "source" };
+        run_git_command(
+            &format!("publish fetched {role} tracking ref"),
+            &["update-ref", tracking_ref, oid],
+            &[],
+            verbose,
+        )?;
+    }
     let (review_branch, is_new) = match selection {
         ReviewBranchSelection::Existing(name) => {
             run_git_command("switch to review branch", &["switch", &name], &[], verbose)?;
@@ -266,6 +286,8 @@ fn apply_review_plan(plan: ReviewPlan, verbose: bool) -> Result<bool, ReviewErro
         run_git_command(
             "auto-approve earlier commits",
             &[
+                "-c",
+                "rerere.enabled=false",
                 "merge",
                 "--squash",
                 "--ff",
@@ -292,6 +314,8 @@ fn apply_review_plan(plan: ReviewPlan, verbose: bool) -> Result<bool, ReviewErro
     run_git_command(
         "squash merge remaining changes",
         &[
+            "-c",
+            "rerere.enabled=false",
             "merge",
             "--squash",
             "--ff",

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,6 +6,14 @@ use crate::git::{
 use crate::review::{ReviewError, ReviewTransaction};
 use std::ops::Not;
 
+struct ReviewPlan {
+    metadata: ReviewMetadata,
+    merge_base: String,
+    auto_approve_parent: Option<String>,
+    selection: ReviewBranchSelection,
+    scope: ReviewScope,
+}
+
 /// Prepare the review branch using Squash Merge approach.
 ///
 /// # Arguments
@@ -22,18 +30,16 @@ pub fn prepare_review_branch(
     stop_at: Option<&str>,
     verbose: bool,
 ) -> Result<bool, ReviewError> {
-    let mut transaction = ReviewTransaction::begin(verbose)?;
-    transaction
-        .execute(|| prepare_review_branch_inner(to_branch, from_branch, skip_to, stop_at, verbose))
-}
+    // Review preparation never relies on the ambient temporary directory. In particular, Git
+    // launchers on some platforms create helper files there before Cresca can discover the repo.
+    std::env::set_var("TMPDIR", "/tmp");
+    let root = ReviewTransaction::repository_root(verbose)?;
+    std::env::set_current_dir(&root).map_err(|error| {
+        ReviewError::Message(format!(
+            "failed to anchor review preparation at repository root: {error}"
+        ))
+    })?;
 
-fn prepare_review_branch_inner(
-    to_branch: &str,
-    from_branch: &str,
-    skip_to: Option<&str>,
-    stop_at: Option<&str>,
-    verbose: bool,
-) -> Result<bool, ReviewError> {
     if !is_clean(verbose)? {
         return Err(ReviewError::Message(
             "Uncommitted changes found. Please commit or stash them before starting review."
@@ -41,6 +47,18 @@ fn prepare_review_branch_inner(
         ));
     }
 
+    let plan = prepare_review_plan(to_branch, from_branch, skip_to, stop_at, verbose)?;
+    let mut transaction = ReviewTransaction::begin(root, verbose)?;
+    transaction.execute(|| apply_review_plan(plan, verbose))
+}
+
+fn prepare_review_plan(
+    to_branch: &str,
+    from_branch: &str,
+    skip_to: Option<&str>,
+    stop_at: Option<&str>,
+    verbose: bool,
+) -> Result<ReviewPlan, ReviewError> {
     let metadata = ReviewMetadata {
         target: to_branch.to_string(),
         source: from_branch.to_string(),
@@ -48,22 +66,16 @@ fn prepare_review_branch_inner(
     let resolved_to = resolve_remote_tracking_branch(to_branch, verbose)?;
     let resolved_from = resolve_remote_tracking_branch(from_branch, verbose)?;
 
-    let tracking_to = resolved_to.tracking_ref;
-    let tracking_from = resolved_from.tracking_ref;
-
-    // Fetch the target branch
-    run_git_command(
-        &format!("fetch target branch from {}", resolved_to.remote),
-        &["fetch", &resolved_to.remote, &resolved_to.remote_branch],
-        false,
+    let tracking_to = fetch_remote_commit(
+        "target",
+        &resolved_to.remote,
+        &resolved_to.remote_branch,
         verbose,
     )?;
-
-    // Fetch the source branch
-    run_git_command(
-        &format!("fetch source branch from {}", resolved_from.remote),
-        &["fetch", &resolved_from.remote, &resolved_from.remote_branch],
-        false,
+    let tracking_from = fetch_remote_commit(
+        "source",
+        &resolved_from.remote,
+        &resolved_from.remote_branch,
         verbose,
     )?;
 
@@ -71,7 +83,7 @@ fn prepare_review_branch_inner(
     let merge_base_output = run_git_command(
         "get merge base",
         &["merge-base", &tracking_to, &tracking_from],
-        false,
+        &[],
         verbose,
     )?;
     let merge_base = String::from_utf8_lossy(&merge_base_output.stdout)
@@ -82,7 +94,7 @@ fn prepare_review_branch_inner(
     let valid_commits = run_git_command(
         "get valid commit range",
         &["rev-list", &format!("{}..{}", merge_base, tracking_from)],
-        false,
+        &[],
         verbose,
     )?;
     let valid_list = String::from_utf8_lossy(&valid_commits.stdout);
@@ -115,7 +127,7 @@ fn prepare_review_branch_inner(
             let skip_to_commits = run_git_command(
                 "get commits after skip_to",
                 &["rev-list", &format!("{}..{}", skip_hash, tracking_from)],
-                false,
+                &[],
                 verbose,
             )?;
             let skip_to_list = String::from_utf8_lossy(&skip_to_commits.stdout);
@@ -143,7 +155,7 @@ fn prepare_review_branch_inner(
     let scope_end_output = run_git_command(
         "resolve review range endpoint",
         &["rev-parse", "--verify", &scope_end_commit],
-        false,
+        &[],
         verbose,
     )?;
     let scope = ReviewScope {
@@ -157,7 +169,7 @@ fn prepare_review_branch_inner(
         let has_earlier = run_git_command(
             "check earlier commits",
             &["rev-list", &format!("{}..{}", merge_base, parent)],
-            true,
+            &[],
             verbose,
         )?;
         (!has_earlier.stdout.is_empty()).then_some(parent)
@@ -170,21 +182,79 @@ fn prepare_review_branch_inner(
         ReviewBranchSelectionError::Conflict(message) => ReviewError::Message(message),
     })?;
 
+    Ok(ReviewPlan {
+        metadata,
+        merge_base,
+        auto_approve_parent,
+        selection,
+        scope,
+    })
+}
+
+fn fetch_remote_commit(
+    role: &str,
+    remote: &str,
+    remote_branch: &str,
+    verbose: bool,
+) -> Result<String, ReviewError> {
+    let remote_ref = format!("refs/heads/{remote_branch}");
+    let output = run_git_command(
+        &format!("resolve {role} branch on {remote}"),
+        &["ls-remote", "--exit-code", remote, &remote_ref],
+        &[],
+        verbose,
+    )?;
+    let oid = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().next())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            ReviewError::Message(format!(
+                "Remote branch `{remote}/{remote_branch}` did not resolve to a commit."
+            ))
+        })?
+        .to_string();
+    run_git_command(
+        &format!("fetch {role} branch from {remote}"),
+        &[
+            "fetch",
+            "--no-write-fetch-head",
+            "--refmap=",
+            remote,
+            &remote_ref,
+        ],
+        &[],
+        verbose,
+    )?;
+    let commit = format!("{oid}^{{commit}}");
+    let output = run_git_command(
+        &format!("validate fetched {role} commit"),
+        &["rev-parse", "--verify", &commit],
+        &[],
+        verbose,
+    )?;
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn apply_review_plan(plan: ReviewPlan, verbose: bool) -> Result<bool, ReviewError> {
+    let ReviewPlan {
+        metadata,
+        merge_base,
+        auto_approve_parent,
+        selection,
+        scope,
+    } = plan;
     let (review_branch, is_new) = match selection {
         ReviewBranchSelection::Existing(name) => {
-            run_git_command(
-                "switch to review branch",
-                &["switch", &name],
-                false,
-                verbose,
-            )?;
+            run_git_command("switch to review branch", &["switch", &name], &[], verbose)?;
             (name, false)
         }
         ReviewBranchSelection::New(name) => {
             run_git_command(
                 "create review branch from merge-base",
                 &["checkout", "-b", &name, &merge_base],
-                false,
+                &[],
                 verbose,
             )?;
             (name, true)
@@ -205,13 +275,13 @@ fn prepare_review_branch_inner(
                 "theirs",
                 &parent,
             ],
-            false,
+            &[],
             verbose,
         )?;
         run_git_command(
             "commit auto-approved changes",
             &["commit", "--quiet", "-m", "Auto-approve earlier commits"],
-            false,
+            &[],
             verbose,
         )?;
     }
@@ -231,12 +301,12 @@ fn prepare_review_branch_inner(
             "theirs",
             &target_commit,
         ],
-        false,
+        &[],
         verbose,
     )?;
 
     // Unstage changes for review
-    run_git_command("unstage changes for review", &["reset"], false, verbose)?;
+    run_git_command("unstage changes for review", &["reset"], &[], verbose)?;
     if is_new {
         write_review_metadata(&review_branch, &metadata, verbose)?;
     }
@@ -256,21 +326,17 @@ fn prepare_review_branch_inner(
 /// * `Err(())` - If there are no staged changes
 pub fn approve_changes(verbose: bool) -> Result<bool, crate::git::GitCommandError> {
     // Check if there are staged changes
-    let has_staged_changes = run_git_command(
-        "check staged changes",
-        &["diff", "--cached"],
-        false,
-        verbose,
-    )?
-    .stdout
-    .is_empty()
-    .not();
+    let has_staged_changes =
+        run_git_command("check staged changes", &["diff", "--cached"], &[], verbose)?
+            .stdout
+            .is_empty()
+            .not();
 
     if has_staged_changes {
         run_git_command(
             "commit reviewed changes",
             &["commit", "--quiet", "-m", "Approve reviewed changes"],
-            false,
+            &[],
             verbose,
         )?;
     }
@@ -278,10 +344,10 @@ pub fn approve_changes(verbose: bool) -> Result<bool, crate::git::GitCommandErro
     run_git_command(
         "discard unreviewed changes",
         &["restore", "--source=HEAD", "--worktree", "--", "."],
-        false,
+        &[],
         verbose,
     )?;
-    run_git_command("discard untracked files", &["clean", "-fd"], false, verbose)?;
+    run_git_command("discard untracked files", &["clean", "-fd"], &[], verbose)?;
 
     Ok(has_staged_changes)
 }
@@ -315,7 +381,7 @@ pub fn get_review_status(
     let stat_output = run_git_command(
         "get diff stats",
         &["diff", "--stat", "HEAD", compare_ref],
-        false,
+        &[],
         verbose,
     )?;
     let stat_str = String::from_utf8_lossy(&stat_output.stdout);
@@ -348,7 +414,7 @@ pub fn get_review_status(
     let files_output = run_git_command(
         "get changed files",
         &["diff", "--name-only", "HEAD", compare_ref],
-        false,
+        &[],
         verbose,
     )?;
     let files: Vec<String> = String::from_utf8_lossy(&files_output.stdout)

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,10 +1,10 @@
 use crate::git::{
     resolve_remote_tracking_branch, run_git_command, select_review_branch, write_review_metadata,
-    write_review_scope, ReviewBranchSelection, ReviewMetadata, ReviewScope,
+    write_review_scope, ReviewBranchSelection, ReviewBranchSelectionError, ReviewMetadata,
+    ReviewScope,
 };
-use colored::Colorize;
+use crate::review::{ReviewError, ReviewTransaction};
 use std::ops::Not;
-use std::process::exit;
 
 /// Prepare the review branch using Squash Merge approach.
 ///
@@ -21,13 +21,14 @@ pub fn prepare_review_branch(
     skip_to: Option<&str>,
     stop_at: Option<&str>,
     verbose: bool,
-) {
+) -> Result<(), ReviewError> {
+    let mut transaction = ReviewTransaction::begin(verbose)?;
     let metadata = ReviewMetadata {
         target: to_branch.to_string(),
         source: from_branch.to_string(),
     };
-    let resolved_to = resolve_remote_tracking_branch(to_branch, verbose);
-    let resolved_from = resolve_remote_tracking_branch(from_branch, verbose);
+    let resolved_to = resolve_remote_tracking_branch(to_branch, verbose)?;
+    let resolved_from = resolve_remote_tracking_branch(from_branch, verbose)?;
 
     let tracking_to = resolved_to.tracking_ref;
     let tracking_from = resolved_from.tracking_ref;
@@ -38,7 +39,7 @@ pub fn prepare_review_branch(
         &["fetch", &resolved_to.remote, &resolved_to.remote_branch],
         false,
         verbose,
-    );
+    )?;
 
     // Fetch the source branch
     run_git_command(
@@ -46,7 +47,7 @@ pub fn prepare_review_branch(
         &["fetch", &resolved_from.remote, &resolved_from.remote_branch],
         false,
         verbose,
-    );
+    )?;
 
     // Get merge-base
     let merge_base_output = run_git_command(
@@ -54,7 +55,7 @@ pub fn prepare_review_branch(
         &["merge-base", &tracking_to, &tracking_from],
         false,
         verbose,
-    );
+    )?;
     let merge_base = String::from_utf8_lossy(&merge_base_output.stdout)
         .trim()
         .to_string();
@@ -65,7 +66,7 @@ pub fn prepare_review_branch(
         &["rev-list", &format!("{}..{}", merge_base, tracking_from)],
         false,
         verbose,
-    );
+    )?;
     let valid_list = String::from_utf8_lossy(&valid_commits.stdout);
     let valid_hashes: Vec<&str> = valid_list.lines().collect();
 
@@ -73,14 +74,10 @@ pub fn prepare_review_branch(
     if let Some(hash) = skip_to {
         let is_valid = valid_hashes.iter().any(|line| line.starts_with(hash));
         if !is_valid {
-            eprintln!(
-                "{}: Commit {} is not in the range {}..{}",
-                "error".red().bold(),
-                hash,
-                to_branch,
-                from_branch
-            );
-            exit(1);
+            return Err(ReviewError::Message(format!(
+                "Commit {} is not in the range {}..{}",
+                hash, to_branch, from_branch
+            )));
         }
     }
 
@@ -89,14 +86,10 @@ pub fn prepare_review_branch(
         // stop_at must be in the valid range
         let is_valid = valid_hashes.iter().any(|line| line.starts_with(hash));
         if !is_valid {
-            eprintln!(
-                "{}: Commit {} is not in the range {}..{}",
-                "error".red().bold(),
-                hash,
-                to_branch,
-                from_branch
-            );
-            exit(1);
+            return Err(ReviewError::Message(format!(
+                "Commit {} is not in the range {}..{}",
+                hash, to_branch, from_branch
+            )));
         }
 
         // If skip_to is also specified, stop_at must be at or after skip_to
@@ -106,7 +99,7 @@ pub fn prepare_review_branch(
                 &["rev-list", &format!("{}..{}", skip_hash, tracking_from)],
                 false,
                 verbose,
-            );
+            )?;
             let skip_to_list = String::from_utf8_lossy(&skip_to_commits.stdout);
             let is_after_skip = skip_to_list.lines().any(|line| line.starts_with(hash))
                 || valid_hashes
@@ -119,13 +112,10 @@ pub fn prepare_review_branch(
                 .any(|line| line.starts_with(hash) && line.starts_with(skip_hash));
 
             if !is_after_skip && !stop_at_equals_skip_to {
-                eprintln!(
-                    "{}: --stop-at ({}) must be at or after --skip-to ({})",
-                    "error".red().bold(),
-                    hash,
-                    skip_hash
-                );
-                exit(1);
+                return Err(ReviewError::Message(format!(
+                    "--stop-at ({}) must be at or after --skip-to ({})",
+                    hash, skip_hash
+                )));
             }
         }
     }
@@ -137,47 +127,55 @@ pub fn prepare_review_branch(
         &["rev-parse", "--verify", &scope_end_commit],
         false,
         verbose,
-    );
+    )?;
     let scope = ReviewScope {
         end_oid: String::from_utf8_lossy(&scope_end_output.stdout)
             .trim()
             .to_string(),
     };
 
-    let (review_branch, is_new) = match select_review_branch(&metadata, verbose) {
-        ReviewBranchSelection::Existing(name) => {
-            run_git_command(
-                "switch to review branch",
-                &["switch", &name],
-                false,
-                verbose,
-            );
-            (name, false)
-        }
-        ReviewBranchSelection::New(name) => {
-            run_git_command(
-                "create review branch from merge-base",
-                &["checkout", "-b", &name, &merge_base],
-                false,
-                verbose,
-            );
-            (name, true)
-        }
-    };
-
-    if let Some(hash) = skip_to {
-        // Auto-approve commits before skip_to by squash merging them
+    let auto_approve_parent = if let Some(hash) = skip_to {
         let parent = format!("{}^", hash);
-
-        // Check if there are commits before skip_to
         let has_earlier = run_git_command(
             "check earlier commits",
             &["rev-list", &format!("{}..{}", merge_base, parent)],
             true,
             verbose,
-        );
+        )?;
+        (!has_earlier.stdout.is_empty()).then_some(parent)
+    } else {
+        None
+    };
 
-        if !has_earlier.stdout.is_empty() {
+    let selection = select_review_branch(&metadata, verbose).map_err(|error| match error {
+        ReviewBranchSelectionError::Git(error) => ReviewError::Git(error),
+        ReviewBranchSelectionError::Conflict(message) => ReviewError::Message(message),
+    })?;
+
+    transaction.execute(|| {
+        let (review_branch, is_new) = match selection {
+            ReviewBranchSelection::Existing(name) => {
+                run_git_command(
+                    "switch to review branch",
+                    &["switch", &name],
+                    false,
+                    verbose,
+                )?;
+                (name, false)
+            }
+            ReviewBranchSelection::New(name) => {
+                run_git_command(
+                    "create review branch from merge-base",
+                    &["checkout", "-b", &name, &merge_base],
+                    false,
+                    verbose,
+                )?;
+                (name, true)
+            }
+        };
+
+        if let Some(parent) = auto_approve_parent {
+            // Auto-approve commits before skip_to by squash merging them
             run_git_command(
                 "auto-approve earlier commits",
                 &[
@@ -192,41 +190,42 @@ pub fn prepare_review_branch(
                 ],
                 false,
                 verbose,
-            );
+            )?;
             run_git_command(
                 "commit auto-approved changes",
                 &["commit", "--quiet", "-m", "Auto-approve earlier commits"],
                 false,
                 verbose,
-            );
+            )?;
         }
-    }
 
-    let target_commit = scope.end_oid.clone();
+        let target_commit = scope.end_oid.clone();
 
-    // Squash merge remaining changes
-    run_git_command(
-        "squash merge remaining changes",
-        &[
-            "merge",
-            "--squash",
-            "--ff",
-            "--quiet",
-            "--no-stat",
-            "-X",
-            "theirs",
-            &target_commit,
-        ],
-        false,
-        verbose,
-    );
+        // Squash merge remaining changes
+        run_git_command(
+            "squash merge remaining changes",
+            &[
+                "merge",
+                "--squash",
+                "--ff",
+                "--quiet",
+                "--no-stat",
+                "-X",
+                "theirs",
+                &target_commit,
+            ],
+            false,
+            verbose,
+        )?;
 
-    // Unstage changes for review
-    run_git_command("unstage changes for review", &["reset"], false, verbose);
-    if is_new {
-        write_review_metadata(&review_branch, &metadata, verbose);
-    }
-    write_review_scope(&review_branch, &scope, verbose);
+        // Unstage changes for review
+        run_git_command("unstage changes for review", &["reset"], false, verbose)?;
+        if is_new {
+            write_review_metadata(&review_branch, &metadata, verbose)?;
+        }
+        write_review_scope(&review_branch, &scope, verbose)?;
+        Ok(())
+    })
 }
 
 /// Commit reviewed changes and discard unreviewed ones
@@ -239,14 +238,14 @@ pub fn prepare_review_branch(
 ///
 /// * `Ok(())` - If there are staged changes
 /// * `Err(())` - If there are no staged changes
-pub fn approve_changes(verbose: bool) -> Result<(), ()> {
+pub fn approve_changes(verbose: bool) -> Result<bool, crate::git::GitCommandError> {
     // Check if there are staged changes
     let has_staged_changes = run_git_command(
         "check staged changes",
         &["diff", "--cached"],
         false,
         verbose,
-    )
+    )?
     .stdout
     .is_empty()
     .not();
@@ -257,7 +256,7 @@ pub fn approve_changes(verbose: bool) -> Result<(), ()> {
             &["commit", "--quiet", "-m", "Approve reviewed changes"],
             false,
             verbose,
-        );
+        )?;
     }
 
     run_git_command(
@@ -265,13 +264,10 @@ pub fn approve_changes(verbose: bool) -> Result<(), ()> {
         &["restore", "--source=HEAD", "--worktree", "--", "."],
         false,
         verbose,
-    );
-    run_git_command("discard untracked files", &["clean", "-fd"], false, verbose);
+    )?;
+    run_git_command("discard untracked files", &["clean", "-fd"], false, verbose)?;
 
-    match has_staged_changes {
-        true => Ok(()),
-        false => Err(()),
-    }
+    Ok(has_staged_changes)
 }
 
 /// Review status information
@@ -294,14 +290,18 @@ pub struct ReviewStatus {
 /// # Returns
 ///
 /// * `ReviewStatus` - The remaining diff statistics
-pub fn get_review_status(compare_ref: &str, display_label: &str, verbose: bool) -> ReviewStatus {
+pub fn get_review_status(
+    compare_ref: &str,
+    display_label: &str,
+    verbose: bool,
+) -> Result<ReviewStatus, crate::git::GitCommandError> {
     // Get diff stats summary (use HEAD..branch for direct comparison, not HEAD...branch)
     let stat_output = run_git_command(
         "get diff stats",
         &["diff", "--stat", "HEAD", compare_ref],
         false,
         verbose,
-    );
+    )?;
     let stat_str = String::from_utf8_lossy(&stat_output.stdout);
 
     // Parse stats from last line (e.g., " 4 files changed, 7 insertions(+), 2 deletions(-)")
@@ -334,18 +334,18 @@ pub fn get_review_status(compare_ref: &str, display_label: &str, verbose: bool) 
         &["diff", "--name-only", "HEAD", compare_ref],
         false,
         verbose,
-    );
+    )?;
     let files: Vec<String> = String::from_utf8_lossy(&files_output.stdout)
         .lines()
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string())
         .collect();
 
-    ReviewStatus {
+    Ok(ReviewStatus {
         display_label: display_label.to_string(),
         file_count,
         insertions,
         deletions,
         files,
-    }
+    })
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,5 +1,6 @@
 use colored::Colorize;
-use std::process::{Command, ExitStatus, Output};
+use std::io::Write;
+use std::process::{Command, ExitStatus, Output, Stdio};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct GitCommandError {
@@ -298,19 +299,20 @@ pub fn read_review_scope(branch: &str, verbose: bool) -> Result<ReviewScope, Rev
     {
         return Err(ReviewScopeError::Invalid);
     }
-    let revision = format!("{end_oid}^{{commit}}");
-    let output = run_git_command(
+    let revision = format!("{end_oid}^{{commit}}\n");
+    let output = run_git_command_with_input(
         "validate review range endpoint",
-        &["rev-parse", "--verify", &revision],
-        &[1, 128],
+        &["cat-file", "--batch-check=%(objectname)"],
+        revision.as_bytes(),
+        &[],
         verbose,
     )
     .map_err(ReviewScopeError::Git)?;
-    if !output.status.success() {
+    let result = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if result.ends_with(" missing") {
         return Err(ReviewScopeError::UnavailableCommit(end_oid.to_string()));
     }
-    let canonical = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if canonical != end_oid {
+    if result != end_oid {
         return Err(ReviewScopeError::Invalid);
     }
     Ok(ReviewScope {
@@ -344,7 +346,55 @@ pub fn run_git_command(
     if args.first() == Some(&"status") {
         command.env("GIT_OPTIONAL_LOCKS", "0");
     }
-    let output = command.output();
+    evaluate_git_output(
+        description,
+        args,
+        allowed_exit_codes,
+        verbose,
+        command.output(),
+    )
+}
+
+pub fn run_git_command_with_input(
+    description: &str,
+    args: &[&str],
+    input: &[u8],
+    allowed_exit_codes: &[i32],
+    verbose: bool,
+) -> Result<Output, GitCommandError> {
+    if verbose {
+        println!("[git {}]", args.join(" ").yellow());
+    }
+    let mut command = Command::new("git");
+    command
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let output = match command.spawn() {
+        Ok(mut child) => {
+            let write_result = child
+                .stdin
+                .take()
+                .expect("piped Git stdin must be available")
+                .write_all(input);
+            match (write_result, child.wait_with_output()) {
+                (Err(error), Ok(output)) if output.status.success() => Err(error),
+                (_, output) => output,
+            }
+        }
+        Err(error) => Err(error),
+    };
+    evaluate_git_output(description, args, allowed_exit_codes, verbose, output)
+}
+
+fn evaluate_git_output(
+    description: &str,
+    args: &[&str],
+    allowed_exit_codes: &[i32],
+    verbose: bool,
+    output: std::io::Result<Output>,
+) -> Result<Output, GitCommandError> {
     match output {
         Ok(output) => {
             if output.status.success() && !output.stdout.is_empty() && verbose {
@@ -438,7 +488,7 @@ pub fn resolve_remote_tracking_branch(
             "--quiet",
             &format!("refs/remotes/{}", branch_or_ref),
         ],
-        &[1, 128],
+        &[1],
         verbose,
     )?;
 
@@ -474,19 +524,22 @@ pub fn resolve_remote_tracking_branch(
     let upstream_output = run_git_command(
         "get upstream branch",
         &[
-            "rev-parse",
-            "--abbrev-ref",
-            &format!("{}@{{upstream}}", branch_or_ref),
+            "for-each-ref",
+            "--format=%(refname) %(upstream:short)",
+            &format!("refs/heads/{branch_or_ref}"),
         ],
-        &[1, 128],
+        &[],
         verbose,
     )?;
 
-    if upstream_output.status.success() {
-        let tracking_ref = String::from_utf8_lossy(&upstream_output.stdout)
-            .trim()
-            .to_string();
-
+    let local_ref = format!("refs/heads/{branch_or_ref}");
+    let tracking_ref = String::from_utf8_lossy(&upstream_output.stdout)
+        .lines()
+        .filter_map(|line| line.split_once(' '))
+        .find_map(|(name, upstream)| (name == local_ref).then_some(upstream))
+        .unwrap_or_default()
+        .to_string();
+    if !tracking_ref.is_empty() {
         // Extract remote and remote_branch from tracking_ref using the configured remote for the branch
         let remote_output = run_git_command(
             "get configured remote",

--- a/src/git.rs
+++ b/src/git.rs
@@ -89,7 +89,7 @@ fn local_branch_exists(branch: &str, verbose: bool) -> Result<bool, GitCommandEr
             "--quiet",
             &format!("refs/heads/{branch}"),
         ],
-        true,
+        &[1],
         verbose,
     )?
     .status
@@ -150,7 +150,7 @@ fn review_config_values(
     let output = run_git_command(
         "read review metadata",
         &["config", "--local", "--get-all", &key],
-        true,
+        &[1],
         verbose,
     )?;
     if output.status.success() {
@@ -220,7 +220,7 @@ pub fn write_review_metadata(
         run_git_command(
             "clear review metadata version marker",
             &["config", "--local", "--unset-all", &version_key],
-            false,
+            &[],
             verbose,
         )?;
     }
@@ -233,7 +233,7 @@ pub fn write_review_metadata(
             &target_key,
             &metadata.target,
         ],
-        false,
+        &[],
         verbose,
     )?;
     run_git_command(
@@ -245,7 +245,7 @@ pub fn write_review_metadata(
             &source_key,
             &metadata.source,
         ],
-        false,
+        &[],
         verbose,
     )?;
     run_git_command(
@@ -257,7 +257,7 @@ pub fn write_review_metadata(
             &version_key,
             REVIEW_METADATA_VERSION,
         ],
-        false,
+        &[],
         verbose,
     )?;
     Ok(())
@@ -273,7 +273,7 @@ pub fn write_review_scope(
     run_git_command(
         "record review range",
         &["config", "--local", "--replace-all", &key, &value],
-        false,
+        &[],
         verbose,
     )?;
     Ok(())
@@ -302,7 +302,7 @@ pub fn read_review_scope(branch: &str, verbose: bool) -> Result<ReviewScope, Rev
     let output = run_git_command(
         "validate review range endpoint",
         &["rev-parse", "--verify", &revision],
-        true,
+        &[1, 128],
         verbose,
     )
     .map_err(ReviewScopeError::Git)?;
@@ -324,7 +324,7 @@ pub fn read_review_scope(branch: &str, verbose: bool) -> Result<ReviewScope, Rev
 ///
 /// * `description` - The description of the git command.
 /// * `args` - The arguments to pass to the git command.
-/// * `maybe_error` - Whether the git command might fail intentionally.
+/// * `allowed_exit_codes` - Exact nonzero exit codes accepted for an expected negative probe.
 /// * `verbose` - Whether to print the git command and its output.
 ///
 /// # Returns
@@ -333,19 +333,28 @@ pub fn read_review_scope(branch: &str, verbose: bool) -> Result<ReviewScope, Rev
 pub fn run_git_command(
     description: &str,
     args: &[&str],
-    maybe_error: bool,
+    allowed_exit_codes: &[i32],
     verbose: bool,
 ) -> Result<Output, GitCommandError> {
     if verbose {
         println!("[git {}]", args.join(" ").yellow());
     }
-    let output = Command::new("git").args(args).output();
+    let mut command = Command::new("git");
+    command.args(args);
+    if args.first() == Some(&"status") {
+        command.env("GIT_OPTIONAL_LOCKS", "0");
+    }
+    let output = command.output();
     match output {
         Ok(output) => {
             if output.status.success() && !output.stdout.is_empty() && verbose {
                 println!("{}", String::from_utf8_lossy(&output.stdout));
             }
-            if !output.status.success() && !maybe_error {
+            let allowed = output
+                .status
+                .code()
+                .is_some_and(|code| allowed_exit_codes.contains(&code));
+            if !output.status.success() && !allowed {
                 return Err(GitCommandError {
                     description: description.to_string(),
                     args: args.iter().map(|arg| (*arg).to_string()).collect(),
@@ -375,7 +384,7 @@ pub fn is_clean(verbose: bool) -> Result<bool, GitCommandError> {
     Ok(run_git_command(
         "check working directory status",
         &["status", "--porcelain"],
-        false,
+        &[],
         verbose,
     )?
     .stdout
@@ -386,7 +395,7 @@ pub fn current_branch_name(verbose: bool) -> Result<String, GitCommandError> {
     let output = run_git_command(
         "get current branch",
         &["rev-parse", "--abbrev-ref", "HEAD"],
-        false,
+        &[],
         verbose,
     )?;
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
@@ -429,14 +438,14 @@ pub fn resolve_remote_tracking_branch(
             "--quiet",
             &format!("refs/remotes/{}", branch_or_ref),
         ],
-        true,
+        &[1, 128],
         verbose,
     )?;
 
     if verify_output.status.success() {
         // It's a remote tracking branch. We need to split it into remote and branch.
         // Assuming format is <remote>/<branch_name>. We can get remotes to find the remote name.
-        let remotes_output = run_git_command("get remotes", &["remote"], false, verbose)?;
+        let remotes_output = run_git_command("get remotes", &["remote"], &[], verbose)?;
         let remotes_str = String::from_utf8_lossy(&remotes_output.stdout);
         let mut best_remote = String::new();
         for remote in remotes_str.lines() {
@@ -469,7 +478,7 @@ pub fn resolve_remote_tracking_branch(
             "--abbrev-ref",
             &format!("{}@{{upstream}}", branch_or_ref),
         ],
-        true,
+        &[1, 128],
         verbose,
     )?;
 
@@ -482,7 +491,7 @@ pub fn resolve_remote_tracking_branch(
         let remote_output = run_git_command(
             "get configured remote",
             &["config", &format!("branch.{}.remote", branch_or_ref)],
-            true,
+            &[1],
             verbose,
         )?;
 
@@ -520,7 +529,7 @@ pub fn resolve_remote_tracking_branch(
             "origin",
             &format!("refs/heads/{}", branch_or_ref),
         ],
-        true,
+        &[2],
         verbose,
     )?;
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -329,7 +329,7 @@ pub fn read_review_scope(branch: &str, verbose: bool) -> Result<ReviewScope, Rev
 ///
 /// # Returns
 ///
-/// * `std::process::Output` - The output of the git command.
+/// * `Result<Output, GitCommandError>` - The output, or a fully captured Git failure.
 pub fn run_git_command(
     description: &str,
     args: &[&str],

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,5 +1,14 @@
 use colored::Colorize;
-use std::process::{exit, Command, Output};
+use std::process::{Command, ExitStatus, Output};
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct GitCommandError {
+    pub description: String,
+    pub args: Vec<String>,
+    pub status: Option<ExitStatus>,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+}
 
 pub const REVIEW_METADATA_VERSION: &str = "1";
 pub const REVIEW_SCOPE_VERSION: &str = "1";
@@ -21,6 +30,7 @@ pub enum ReviewMetadataError {
     Missing,
     UnsupportedVersion(String),
     Invalid,
+    Git(GitCommandError),
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -30,12 +40,19 @@ pub enum ReviewScopeError {
     UnsupportedVersion(String),
     Invalid,
     UnavailableCommit(String),
+    Git(GitCommandError),
 }
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum ReviewBranchSelection {
     New(String),
     Existing(String),
+}
+
+#[derive(Debug)]
+pub enum ReviewBranchSelectionError {
+    Git(GitCommandError),
+    Conflict(String),
 }
 
 fn readable_review_branch(metadata: &ReviewMetadata) -> String {
@@ -63,8 +80,8 @@ fn suffixed_review_branch(base: &str, metadata: &ReviewMetadata) -> String {
     format!("{base}-{:016x}", review_identity_hash(metadata))
 }
 
-fn local_branch_exists(branch: &str, verbose: bool) -> bool {
-    run_git_command(
+fn local_branch_exists(branch: &str, verbose: bool) -> Result<bool, GitCommandError> {
+    Ok(run_git_command(
         "check existence of review branch",
         &[
             "show-ref",
@@ -74,77 +91,103 @@ fn local_branch_exists(branch: &str, verbose: bool) -> bool {
         ],
         true,
         verbose,
-    )
+    )?
     .status
-    .success()
+    .success())
 }
 
-pub fn select_review_branch(metadata: &ReviewMetadata, verbose: bool) -> ReviewBranchSelection {
+pub fn select_review_branch(
+    metadata: &ReviewMetadata,
+    verbose: bool,
+) -> Result<ReviewBranchSelection, ReviewBranchSelectionError> {
     let base = readable_review_branch(metadata);
-    let base_exists = local_branch_exists(&base, verbose);
+    let base_exists =
+        local_branch_exists(&base, verbose).map_err(ReviewBranchSelectionError::Git)?;
     match (base_exists, read_review_metadata(&base, verbose)) {
-        (false, Err(ReviewMetadataError::Missing)) => return ReviewBranchSelection::New(base),
+        (false, Err(ReviewMetadataError::Missing)) => return Ok(ReviewBranchSelection::New(base)),
         (true, Ok(existing)) if existing == *metadata => {
-            return ReviewBranchSelection::Existing(base)
+            return Ok(ReviewBranchSelection::Existing(base))
+        }
+        (_, Err(ReviewMetadataError::Git(error))) => {
+            return Err(ReviewBranchSelectionError::Git(error))
         }
         _ => {}
     }
 
     let suffix = suffixed_review_branch(&base, metadata);
-    let suffix_exists = local_branch_exists(&suffix, verbose);
+    let suffix_exists =
+        local_branch_exists(&suffix, verbose).map_err(ReviewBranchSelectionError::Git)?;
     match (suffix_exists, read_review_metadata(&suffix, verbose)) {
-        (false, Err(ReviewMetadataError::Missing)) => return ReviewBranchSelection::New(suffix),
+        (false, Err(ReviewMetadataError::Missing)) => {
+            return Ok(ReviewBranchSelection::New(suffix))
+        }
         (true, Ok(existing)) if existing == *metadata => {
-            return ReviewBranchSelection::Existing(suffix)
+            return Ok(ReviewBranchSelection::Existing(suffix))
+        }
+        (_, Err(ReviewMetadataError::Git(error))) => {
+            return Err(ReviewBranchSelectionError::Git(error))
         }
         _ => {}
     }
 
-    eprintln!(
-        "{}: Found conflicting review branches `{}` and `{}` with missing, invalid, or different metadata. Inspect and delete or rename the conflicting local review branch before retrying.",
-        "error".red().bold(),
+    Err(ReviewBranchSelectionError::Conflict(format!(
+        "Found conflicting review branches `{}` and `{}` with missing, invalid, or different metadata. Inspect and delete or rename the conflicting local review branch before retrying.",
         base,
         suffix
-    );
-    exit(1);
+    )))
 }
 
 fn review_config_key(branch: &str, field: &str) -> String {
     format!("branch.{branch}.cresca-{field}")
 }
 
-fn review_config_values(branch: &str, field: &str, verbose: bool) -> Vec<String> {
+fn review_config_values(
+    branch: &str,
+    field: &str,
+    verbose: bool,
+) -> Result<Vec<String>, GitCommandError> {
     let key = review_config_key(branch, field);
     let output = run_git_command(
         "read review metadata",
         &["config", "--local", "--get-all", &key],
         true,
         verbose,
-    );
+    )?;
     if output.status.success() {
-        return String::from_utf8_lossy(&output.stdout)
+        return Ok(String::from_utf8_lossy(&output.stdout)
             .lines()
             .map(str::to_owned)
-            .collect();
+            .collect());
     }
 
     if output.status.code() == Some(1) && output.stderr.is_empty() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
-    eprintln!("{}: Failed to read review metadata.", "error".red().bold());
-    eprintln!("Original error from git:");
-    eprintln!("\t{}", String::from_utf8_lossy(&output.stderr));
-    exit(1);
+    Err(GitCommandError {
+        description: "read review metadata".to_string(),
+        args: vec![
+            "config".to_string(),
+            "--local".to_string(),
+            "--get-all".to_string(),
+            key,
+        ],
+        status: Some(output.status),
+        stdout: output.stdout,
+        stderr: output.stderr,
+    })
 }
 
 pub fn read_review_metadata(
     branch: &str,
     verbose: bool,
 ) -> Result<ReviewMetadata, ReviewMetadataError> {
-    let versions = review_config_values(branch, "version", verbose);
-    let targets = review_config_values(branch, "target", verbose);
-    let sources = review_config_values(branch, "source", verbose);
+    let versions =
+        review_config_values(branch, "version", verbose).map_err(ReviewMetadataError::Git)?;
+    let targets =
+        review_config_values(branch, "target", verbose).map_err(ReviewMetadataError::Git)?;
+    let sources =
+        review_config_values(branch, "source", verbose).map_err(ReviewMetadataError::Git)?;
 
     match (versions.as_slice(), targets.as_slice(), sources.as_slice()) {
         ([version], [target], [source])
@@ -163,19 +206,23 @@ pub fn read_review_metadata(
     }
 }
 
-pub fn write_review_metadata(branch: &str, metadata: &ReviewMetadata, verbose: bool) {
+pub fn write_review_metadata(
+    branch: &str,
+    metadata: &ReviewMetadata,
+    verbose: bool,
+) -> Result<(), GitCommandError> {
     let version_key = review_config_key(branch, "version");
     let target_key = review_config_key(branch, "target");
     let source_key = review_config_key(branch, "source");
 
-    let existing_versions = review_config_values(branch, "version", verbose);
+    let existing_versions = review_config_values(branch, "version", verbose)?;
     if !existing_versions.is_empty() {
         run_git_command(
             "clear review metadata version marker",
             &["config", "--local", "--unset-all", &version_key],
             false,
             verbose,
-        );
+        )?;
     }
     run_git_command(
         "record review target",
@@ -188,7 +235,7 @@ pub fn write_review_metadata(branch: &str, metadata: &ReviewMetadata, verbose: b
         ],
         false,
         verbose,
-    );
+    )?;
     run_git_command(
         "record review source",
         &[
@@ -200,7 +247,7 @@ pub fn write_review_metadata(branch: &str, metadata: &ReviewMetadata, verbose: b
         ],
         false,
         verbose,
-    );
+    )?;
     run_git_command(
         "commit review metadata",
         &[
@@ -212,10 +259,15 @@ pub fn write_review_metadata(branch: &str, metadata: &ReviewMetadata, verbose: b
         ],
         false,
         verbose,
-    );
+    )?;
+    Ok(())
 }
 
-pub fn write_review_scope(branch: &str, scope: &ReviewScope, verbose: bool) {
+pub fn write_review_scope(
+    branch: &str,
+    scope: &ReviewScope,
+    verbose: bool,
+) -> Result<(), GitCommandError> {
     let key = review_config_key(branch, "scope");
     let value = format!("{}:{}", REVIEW_SCOPE_VERSION, scope.end_oid);
     run_git_command(
@@ -223,11 +275,12 @@ pub fn write_review_scope(branch: &str, scope: &ReviewScope, verbose: bool) {
         &["config", "--local", "--replace-all", &key, &value],
         false,
         verbose,
-    );
+    )?;
+    Ok(())
 }
 
 pub fn read_review_scope(branch: &str, verbose: bool) -> Result<ReviewScope, ReviewScopeError> {
-    let values = review_config_values(branch, "scope", verbose);
+    let values = review_config_values(branch, "scope", verbose).map_err(ReviewScopeError::Git)?;
     let value = match values.as_slice() {
         [] => return Err(ReviewScopeError::Missing),
         [value] => value,
@@ -251,7 +304,8 @@ pub fn read_review_scope(branch: &str, verbose: bool) -> Result<ReviewScope, Rev
         &["rev-parse", "--verify", &revision],
         true,
         verbose,
-    );
+    )
+    .map_err(ReviewScopeError::Git)?;
     if !output.status.success() {
         return Err(ReviewScopeError::UnavailableCommit(end_oid.to_string()));
     }
@@ -281,7 +335,7 @@ pub fn run_git_command(
     args: &[&str],
     maybe_error: bool,
     verbose: bool,
-) -> Output {
+) -> Result<Output, GitCommandError> {
     if verbose {
         println!("[git {}]", args.join(" ").yellow());
     }
@@ -292,18 +346,23 @@ pub fn run_git_command(
                 println!("{}", String::from_utf8_lossy(&output.stdout));
             }
             if !output.status.success() && !maybe_error {
-                eprintln!("{}: Failed to {}.", "error".red().bold(), description);
-                eprintln!("Original error from git:");
-                eprintln!("\t{}", String::from_utf8_lossy(&output.stderr));
-                exit(1);
+                return Err(GitCommandError {
+                    description: description.to_string(),
+                    args: args.iter().map(|arg| (*arg).to_string()).collect(),
+                    status: Some(output.status),
+                    stdout: output.stdout,
+                    stderr: output.stderr,
+                });
             }
-            output
+            Ok(output)
         }
-        Err(e) => {
-            eprintln!("{}: Failed to {}.", "error".red().bold(), description);
-            eprintln!("{}", e);
-            exit(1);
-        }
+        Err(e) => Err(GitCommandError {
+            description: description.to_string(),
+            args: args.iter().map(|arg| (*arg).to_string()).collect(),
+            status: None,
+            stdout: Vec::new(),
+            stderr: e.to_string().into_bytes(),
+        }),
     }
 }
 
@@ -312,29 +371,29 @@ pub fn run_git_command(
 /// # Arguments
 ///
 /// * `verbose` - Whether to print the git command and its output.
-pub fn is_clean(verbose: bool) -> bool {
-    run_git_command(
+pub fn is_clean(verbose: bool) -> Result<bool, GitCommandError> {
+    Ok(run_git_command(
         "check working directory status",
         &["status", "--porcelain"],
         false,
         verbose,
-    )
+    )?
     .stdout
-    .is_empty()
+    .is_empty())
 }
 
-pub fn current_branch_name(verbose: bool) -> String {
+pub fn current_branch_name(verbose: bool) -> Result<String, GitCommandError> {
     let output = run_git_command(
         "get current branch",
         &["rev-parse", "--abbrev-ref", "HEAD"],
         false,
         verbose,
-    );
-    String::from_utf8_lossy(&output.stdout).trim().to_string()
+    )?;
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 pub fn current_review_metadata(verbose: bool) -> Result<ReviewMetadata, ReviewMetadataError> {
-    let branch = current_branch_name(verbose);
+    let branch = current_branch_name(verbose).map_err(ReviewMetadataError::Git)?;
     if !branch.starts_with("review-") {
         return Err(ReviewMetadataError::InvalidBranchName);
     }
@@ -357,7 +416,10 @@ pub struct ResolvedBranch {
 /// 1. If it's already a valid remote tracking branch (e.g., origin/main).
 /// 2. If it's a local branch with an upstream configured (e.g., @{upstream}).
 /// 3. Fallback: assumes it's on 'origin' if it exists there.
-pub fn resolve_remote_tracking_branch(branch_or_ref: &str, verbose: bool) -> ResolvedBranch {
+pub fn resolve_remote_tracking_branch(
+    branch_or_ref: &str,
+    verbose: bool,
+) -> Result<ResolvedBranch, GitCommandError> {
     // 1. Check if it's already a valid remote-tracking branch
     let verify_output = run_git_command(
         "verify if branch is already a remote tracking branch",
@@ -369,12 +431,12 @@ pub fn resolve_remote_tracking_branch(branch_or_ref: &str, verbose: bool) -> Res
         ],
         true,
         verbose,
-    );
+    )?;
 
     if verify_output.status.success() {
         // It's a remote tracking branch. We need to split it into remote and branch.
         // Assuming format is <remote>/<branch_name>. We can get remotes to find the remote name.
-        let remotes_output = run_git_command("get remotes", &["remote"], false, verbose);
+        let remotes_output = run_git_command("get remotes", &["remote"], false, verbose)?;
         let remotes_str = String::from_utf8_lossy(&remotes_output.stdout);
         let mut best_remote = String::new();
         for remote in remotes_str.lines() {
@@ -391,11 +453,11 @@ pub fn resolve_remote_tracking_branch(branch_or_ref: &str, verbose: bool) -> Res
                 .strip_prefix(&format!("{}/", best_remote))
                 .unwrap()
                 .to_string();
-            return ResolvedBranch {
+            return Ok(ResolvedBranch {
                 remote: best_remote,
                 remote_branch,
                 tracking_ref: branch_or_ref.to_string(),
-            };
+            });
         }
     }
 
@@ -409,7 +471,7 @@ pub fn resolve_remote_tracking_branch(branch_or_ref: &str, verbose: bool) -> Res
         ],
         true,
         verbose,
-    );
+    )?;
 
     if upstream_output.status.success() {
         let tracking_ref = String::from_utf8_lossy(&upstream_output.stdout)
@@ -422,7 +484,7 @@ pub fn resolve_remote_tracking_branch(branch_or_ref: &str, verbose: bool) -> Res
             &["config", &format!("branch.{}.remote", branch_or_ref)],
             true,
             verbose,
-        );
+        )?;
 
         let remote = if remote_output.status.success() {
             String::from_utf8_lossy(&remote_output.stdout)
@@ -441,11 +503,11 @@ pub fn resolve_remote_tracking_branch(branch_or_ref: &str, verbose: bool) -> Res
             branch_or_ref.to_string() // fallback
         };
 
-        return ResolvedBranch {
+        return Ok(ResolvedBranch {
             remote,
             remote_branch,
             tracking_ref,
-        };
+        });
     }
 
     // 3. Fallback: check if the branch exists on any remote (default to 'origin' if it's there)
@@ -460,23 +522,23 @@ pub fn resolve_remote_tracking_branch(branch_or_ref: &str, verbose: bool) -> Res
         ],
         true,
         verbose,
-    );
+    )?;
 
     if ls_remote_output.status.success() {
-        return ResolvedBranch {
+        return Ok(ResolvedBranch {
             remote: "origin".to_string(),
             remote_branch: branch_or_ref.to_string(),
             tracking_ref: format!("origin/{}", branch_or_ref),
-        };
+        });
     }
 
     // If we reach here, we can't reliably resolve it. Default to origin/branch and let git fail natively later
     // if it's really invalid.
-    ResolvedBranch {
+    Ok(ResolvedBranch {
         remote: "origin".to_string(),
         remote_branch: branch_or_ref.to_string(),
         tracking_ref: format!("origin/{}", branch_or_ref),
-    }
+    })
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod git;
+mod review;
 
 use clap::builder::styling::{AnsiColor, Effects};
 use clap::{builder::Styles, ArgAction, Args, Parser, Subcommand};
@@ -10,6 +11,24 @@ use git::{
     resolve_remote_tracking_branch, ReviewMetadata, ReviewMetadataError, ReviewScopeError,
 };
 use std::process::exit;
+
+#[derive(Debug)]
+enum CliError {
+    Git(git::GitCommandError),
+    Review(review::ReviewError),
+}
+
+impl From<git::GitCommandError> for CliError {
+    fn from(error: git::GitCommandError) -> Self {
+        Self::Git(error)
+    }
+}
+
+impl From<review::ReviewError> for CliError {
+    fn from(error: review::ReviewError) -> Self {
+        Self::Review(error)
+    }
+}
 
 const STYLES: Styles = Styles::styled()
     .header(AnsiColor::Green.on_default().effects(Effects::BOLD))
@@ -73,21 +92,30 @@ struct ReviewArgs {
 }
 
 fn main() {
+    if let Err(error) = run() {
+        render_error(&error);
+        exit(1);
+    }
+}
+
+fn run() -> Result<(), CliError> {
     let cli = Cli::parse();
 
     match &cli.command {
         Commands::Approve => {
-            if let Err(error) = current_review_metadata(cli.verbose) {
-                exit_invalid_review_branch(error);
+            match current_review_metadata(cli.verbose) {
+                Ok(_) => {}
+                Err(ReviewMetadataError::Git(error)) => return Err(error.into()),
+                Err(error) => exit_invalid_review_branch(error),
             }
             let res = approve_changes(cli.verbose);
-            match res {
-                Err(_) => println!("There are no reviewed changes to approve. Ending the review."),
-                Ok(_) => println!("Reviewed changes were approved successfully."),
+            match res? {
+                false => println!("There are no reviewed changes to approve. Ending the review."),
+                true => println!("Reviewed changes were approved successfully."),
             };
         }
         Commands::Review(args) => {
-            if !is_clean(cli.verbose) {
+            if !is_clean(cli.verbose)? {
                 eprintln!("{}: Uncommitted changes found. Please commit or stash them before starting review.", "error".red().bold());
                 exit(1);
             }
@@ -98,34 +126,40 @@ fn main() {
                 args.skip_to.as_deref(),
                 args.stop_at.as_deref(),
                 cli.verbose,
-            );
-            if is_clean(cli.verbose) {
+            )?;
+            if is_clean(cli.verbose)? {
                 println!("Review branch prepared successfully. However, it seems like there are no unreviewed changes.");
             } else {
                 println!("Review branch prepared successfully. Stage the changes you have reviewed and run `{}` to approve them.", "cresca approve".green());
             }
         }
         Commands::Status(args) => {
-            let metadata = current_review_metadata(cli.verbose)
-                .unwrap_or_else(|error| exit_invalid_review_branch(error));
+            let metadata = match current_review_metadata(cli.verbose) {
+                Ok(metadata) => metadata,
+                Err(ReviewMetadataError::Git(error)) => return Err(error.into()),
+                Err(error) => exit_invalid_review_branch(error),
+            };
             let (heading, compare_ref, display_label) = if args.all {
-                let resolved = resolve_remote_tracking_branch(&metadata.source, cli.verbose);
+                let resolved = resolve_remote_tracking_branch(&metadata.source, cli.verbose)?;
                 (
                     "full pull request",
                     resolved.tracking_ref,
                     format!("to {}", metadata.source),
                 )
             } else {
-                let branch = current_branch_name(cli.verbose);
-                let scope = read_review_scope(&branch, cli.verbose)
-                    .unwrap_or_else(|error| exit_invalid_review_scope(error, &metadata));
+                let branch = current_branch_name(cli.verbose)?;
+                let scope = match read_review_scope(&branch, cli.verbose) {
+                    Ok(scope) => scope,
+                    Err(ReviewScopeError::Git(error)) => return Err(error.into()),
+                    Err(error) => exit_invalid_review_scope(error, &metadata),
+                };
                 (
                     "current range",
                     scope.end_oid,
                     "in current review range".to_string(),
                 )
             };
-            let status = get_review_status(&compare_ref, &display_label, cli.verbose);
+            let status = get_review_status(&compare_ref, &display_label, cli.verbose)?;
             println!("📋 Review status ({}):", heading);
             println!(
                 "  Remaining diff {}: {} file(s), {} insertion(s), {} deletion(s)",
@@ -149,6 +183,44 @@ fn main() {
             }
         }
     }
+    Ok(())
+}
+
+fn render_error(error: &CliError) {
+    match error {
+        CliError::Git(error) => render_git_error(error),
+        CliError::Review(error) => render_review_error(error),
+    }
+}
+
+fn render_review_error(error: &review::ReviewError) {
+    match error {
+        review::ReviewError::Git(error) => render_git_error(error),
+        review::ReviewError::Message(message) => {
+            eprintln!("{}: {message}", "error".red().bold());
+        }
+        review::ReviewError::Rollback {
+            original,
+            diagnostics,
+        } => {
+            render_review_error(original);
+            eprintln!("Rollback or verification also failed:");
+            eprintln!("{diagnostics}");
+        }
+    }
+}
+
+fn render_git_error(error: &git::GitCommandError) {
+    eprintln!("{}: Failed to {}.", "error".red().bold(), error.description);
+    eprintln!("Git arguments: {}", error.args.join(" "));
+    match error.status {
+        Some(status) => eprintln!("Git exit status: {status}"),
+        None => eprintln!("Git exit status: unavailable"),
+    }
+    eprintln!("Git stdout:");
+    eprintln!("{}", String::from_utf8_lossy(&error.stdout));
+    eprintln!("Git stderr:");
+    eprintln!("{}", String::from_utf8_lossy(&error.stderr));
 }
 
 fn exit_invalid_review_scope(error: ReviewScopeError, metadata: &ReviewMetadata) -> ! {
@@ -161,6 +233,10 @@ fn exit_invalid_review_scope(error: ReviewScopeError, metadata: &ReviewMetadata)
         ReviewScopeError::Invalid => "range metadata is invalid".to_string(),
         ReviewScopeError::UnavailableCommit(oid) => {
             format!("saved range endpoint '{oid}' is unavailable")
+        }
+        ReviewScopeError::Git(error) => {
+            render_git_error(&error);
+            exit(1);
         }
     };
     eprintln!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use clap::{builder::Styles, ArgAction, Args, Parser, Subcommand};
 use colored::Colorize;
 use commands::{approve_changes, get_review_status, prepare_review_branch};
 use git::{
-    current_branch_name, current_review_metadata, is_clean, read_review_scope,
+    current_branch_name, current_review_metadata, read_review_scope,
     resolve_remote_tracking_branch, ReviewMetadata, ReviewMetadataError, ReviewScopeError,
 };
 use std::process::exit;
@@ -115,19 +115,14 @@ fn run() -> Result<(), CliError> {
             };
         }
         Commands::Review(args) => {
-            if !is_clean(cli.verbose)? {
-                eprintln!("{}: Uncommitted changes found. Please commit or stash them before starting review.", "error".red().bold());
-                exit(1);
-            }
-
-            prepare_review_branch(
+            let has_unreviewed_changes = prepare_review_branch(
                 &args.to,
                 &args.from,
                 args.skip_to.as_deref(),
                 args.stop_at.as_deref(),
                 cli.verbose,
             )?;
-            if is_clean(cli.verbose)? {
+            if !has_unreviewed_changes {
                 println!("Review branch prepared successfully. However, it seems like there are no unreviewed changes.");
             } else {
                 println!("Review branch prepared successfully. Stage the changes you have reviewed and run `{}` to approve them.", "cresca approve".green());

--- a/src/review.rs
+++ b/src/review.rs
@@ -1,0 +1,426 @@
+use crate::git::{run_git_command, GitCommandError};
+use std::collections::BTreeMap;
+use std::fs;
+use std::io;
+use std::os::unix::fs::{symlink, MetadataExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+#[derive(Debug)]
+pub enum ReviewError {
+    Git(GitCommandError),
+    Message(String),
+    Rollback {
+        original: Box<ReviewError>,
+        diagnostics: String,
+    },
+}
+
+impl From<GitCommandError> for ReviewError {
+    fn from(error: GitCommandError) -> Self {
+        Self::Git(error)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Entry {
+    Directory { mode: u32 },
+    File { mode: u32, data: Vec<u8> },
+    Symlink { target: PathBuf },
+}
+
+pub struct ReviewTransaction {
+    root: PathBuf,
+    head_ref: Option<String>,
+    head_oid: String,
+    heads: BTreeMap<String, String>,
+    config_path: PathBuf,
+    config: Vec<u8>,
+    index_path: PathBuf,
+    index_existed: bool,
+    worktree: BTreeMap<PathBuf, Entry>,
+    scratch: TempDir,
+    mutation_started: bool,
+    finished: bool,
+    verbose: bool,
+}
+
+impl ReviewTransaction {
+    pub fn begin(verbose: bool) -> Result<Self, ReviewError> {
+        let root_output = run_git_command(
+            "locate repository worktree",
+            &["rev-parse", "--show-toplevel"],
+            false,
+            verbose,
+        )?;
+        let root = PathBuf::from(String::from_utf8_lossy(&root_output.stdout).trim());
+        let head_oid = git_stdout("capture original HEAD", &["rev-parse", "HEAD"], verbose)?;
+        let symbolic = run_git_command(
+            "capture original branch",
+            &["symbolic-ref", "--quiet", "HEAD"],
+            true,
+            verbose,
+        )?;
+        let head_ref = symbolic
+            .status
+            .success()
+            .then(|| String::from_utf8_lossy(&symbolic.stdout).trim().to_string());
+        let heads = read_heads(verbose)?;
+        let config_path = resolve_git_path(&root, "config", verbose)?;
+        let index_path = resolve_git_path(&root, "index", verbose)?;
+        let config = fs::read(&config_path).map_err(|error| {
+            ReviewError::Message(format!("failed to snapshot local config: {error}"))
+        })?;
+        let index = match fs::read(&index_path) {
+            Ok(bytes) => Some(bytes),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+            Err(error) => {
+                return Err(ReviewError::Message(format!(
+                    "failed to snapshot real index: {error}"
+                )))
+            }
+        };
+        let worktree = scan_worktree(&root).map_err(|error| {
+            ReviewError::Message(format!("failed to snapshot worktree: {error}"))
+        })?;
+        let scratch = tempfile::Builder::new()
+            .prefix("cresca-review-")
+            .tempdir()
+            .map_err(|error| {
+                ReviewError::Message(format!("failed to create scratch area: {error}"))
+            })?;
+        if let Some(index) = &index {
+            fs::write(scratch.path().join("index"), index).map_err(|error| {
+                ReviewError::Message(format!("failed to back up real index: {error}"))
+            })?;
+        }
+
+        Ok(Self {
+            root,
+            head_ref,
+            head_oid,
+            heads,
+            config_path,
+            config,
+            index_path,
+            index_existed: index.is_some(),
+            worktree,
+            scratch,
+            mutation_started: false,
+            finished: false,
+            verbose,
+        })
+    }
+
+    pub fn execute<F>(&mut self, operation: F) -> Result<(), ReviewError>
+    where
+        F: FnOnce() -> Result<(), ReviewError>,
+    {
+        self.mutation_started = true;
+        match operation() {
+            Ok(()) => {
+                self.finished = true;
+                Ok(())
+            }
+            Err(original) => {
+                let rollback = self.rollback();
+                self.finished = true;
+                match rollback {
+                    Ok(()) => Err(original),
+                    Err(diagnostics) => Err(ReviewError::Rollback {
+                        original: Box::new(original),
+                        diagnostics,
+                    }),
+                }
+            }
+        }
+    }
+
+    fn rollback(&self) -> Result<(), String> {
+        let mut diagnostics = Vec::new();
+        let run = |description: &str, args: &[&str]| {
+            run_git_command(description, args, false, self.verbose)
+                .map(|_| ())
+                .map_err(|error| format!("{description}: {error:?}"))
+        };
+
+        if let Err(error) = run(
+            "detach HEAD for review rollback",
+            &["checkout", "--detach", "--force", &self.head_oid],
+        ) {
+            diagnostics.push(error);
+        }
+
+        match read_heads(self.verbose) {
+            Ok(current) => {
+                for name in current
+                    .keys()
+                    .filter(|name| !self.heads.contains_key(*name))
+                {
+                    if let Err(error) =
+                        run("remove generated local head", &["update-ref", "-d", name])
+                    {
+                        diagnostics.push(error);
+                    }
+                }
+                for (name, oid) in &self.heads {
+                    if current.get(name) != Some(oid) {
+                        if let Err(error) = run("restore local head", &["update-ref", name, oid]) {
+                            diagnostics.push(error);
+                        }
+                    }
+                }
+            }
+            Err(error) => diagnostics.push(format!("read local heads for rollback: {error:?}")),
+        }
+
+        let checkout_result = match &self.head_ref {
+            Some(reference) => run(
+                "restore original branch",
+                &["checkout", "--force", &reference["refs/heads/".len()..]],
+            ),
+            None => run(
+                "restore detached HEAD",
+                &["checkout", "--detach", "--force", &self.head_oid],
+            ),
+        };
+        if let Err(error) = checkout_result {
+            diagnostics.push(error);
+        }
+
+        if let Err(error) =
+            clear_worktree(&self.root).and_then(|()| restore_worktree(&self.root, &self.worktree))
+        {
+            diagnostics.push(format!("restore worktree: {error}"));
+        }
+        if let Err(error) = fs::write(&self.config_path, &self.config) {
+            diagnostics.push(format!("restore local config: {error}"));
+        }
+        if self.index_existed {
+            match fs::read(self.scratch.path().join("index")) {
+                Ok(index) => {
+                    if let Err(error) = fs::write(&self.index_path, index) {
+                        diagnostics.push(format!("restore real index: {error}"));
+                    }
+                }
+                Err(error) => {
+                    diagnostics.push(format!("restore real index: {error}"));
+                }
+            }
+        } else {
+            match fs::remove_file(&self.index_path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => diagnostics.push(format!("remove generated real index: {error}")),
+            }
+        }
+
+        if let Err(error) = self.verify() {
+            diagnostics.push(error);
+        }
+        if diagnostics.is_empty() {
+            Ok(())
+        } else {
+            Err(diagnostics.join("\n"))
+        }
+    }
+
+    fn verify(&self) -> Result<(), String> {
+        let current_oid = git_stdout("verify restored HEAD", &["rev-parse", "HEAD"], self.verbose)
+            .map_err(|error| format!("verify HEAD: {error:?}"))?;
+        if current_oid != self.head_oid {
+            return Err(format!(
+                "HEAD mismatch: expected {}, found {current_oid}",
+                self.head_oid
+            ));
+        }
+        let symbolic = run_git_command(
+            "verify restored branch",
+            &["symbolic-ref", "--quiet", "HEAD"],
+            true,
+            self.verbose,
+        )
+        .map_err(|error| format!("verify branch: {error:?}"))?;
+        let current_ref = symbolic
+            .status
+            .success()
+            .then(|| String::from_utf8_lossy(&symbolic.stdout).trim().to_string());
+        if current_ref != self.head_ref {
+            return Err(format!(
+                "HEAD attachment mismatch: expected {:?}, found {current_ref:?}",
+                self.head_ref
+            ));
+        }
+        let heads = read_heads(self.verbose).map_err(|error| format!("verify refs: {error:?}"))?;
+        if heads != self.heads {
+            return Err("local heads differ after rollback".to_string());
+        }
+        if fs::read(&self.config_path).map_err(|error| error.to_string())? != self.config {
+            return Err("local config differs after rollback".to_string());
+        }
+        let index = match fs::read(&self.index_path) {
+            Ok(bytes) => Some(bytes),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+            Err(error) => return Err(error.to_string()),
+        };
+        let expected_index = if self.index_existed {
+            Some(fs::read(self.scratch.path().join("index")).map_err(|error| error.to_string())?)
+        } else {
+            None
+        };
+        if index != expected_index {
+            return Err("real index differs after rollback".to_string());
+        }
+        let worktree = scan_worktree(&self.root).map_err(|error| error.to_string())?;
+        if worktree != self.worktree {
+            return Err("worktree differs after rollback".to_string());
+        }
+        Ok(())
+    }
+}
+
+impl Drop for ReviewTransaction {
+    fn drop(&mut self) {
+        if self.mutation_started && !self.finished {
+            let _ = self.rollback();
+        }
+    }
+}
+
+fn git_stdout(description: &str, args: &[&str], verbose: bool) -> Result<String, GitCommandError> {
+    let output = run_git_command(description, args, false, verbose)?;
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn resolve_git_path(root: &Path, name: &str, verbose: bool) -> Result<PathBuf, ReviewError> {
+    let path = git_stdout(
+        &format!("locate Git {name}"),
+        &["rev-parse", "--git-path", name],
+        verbose,
+    )?;
+    let path = PathBuf::from(path);
+    Ok(if path.is_absolute() {
+        path
+    } else {
+        root.join(path)
+    })
+}
+
+fn read_heads(verbose: bool) -> Result<BTreeMap<String, String>, GitCommandError> {
+    let output = run_git_command(
+        "list local heads",
+        &[
+            "for-each-ref",
+            "--sort=refname",
+            "--format=%(refname) %(objectname)",
+            "refs/heads/",
+        ],
+        false,
+        verbose,
+    )?;
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.split_once(' '))
+        .map(|(name, oid)| (name.to_string(), oid.to_string()))
+        .collect())
+}
+
+fn scan_worktree(root: &Path) -> io::Result<BTreeMap<PathBuf, Entry>> {
+    fn visit(
+        root: &Path,
+        directory: &Path,
+        entries: &mut BTreeMap<PathBuf, Entry>,
+    ) -> io::Result<()> {
+        for child in fs::read_dir(directory)? {
+            let child = child?;
+            if directory == root && child.file_name() == ".git" {
+                continue;
+            }
+            let path = child.path();
+            let relative = path
+                .strip_prefix(root)
+                .expect("worktree child must be beneath root")
+                .to_path_buf();
+            let metadata = fs::symlink_metadata(&path)?;
+            if metadata.file_type().is_symlink() {
+                entries.insert(
+                    relative,
+                    Entry::Symlink {
+                        target: fs::read_link(path)?,
+                    },
+                );
+            } else if metadata.is_dir() {
+                entries.insert(
+                    relative.clone(),
+                    Entry::Directory {
+                        mode: metadata.mode(),
+                    },
+                );
+                visit(root, &path, entries)?;
+            } else if metadata.is_file() {
+                entries.insert(
+                    relative,
+                    Entry::File {
+                        mode: metadata.mode(),
+                        data: fs::read(path)?,
+                    },
+                );
+            }
+        }
+        Ok(())
+    }
+
+    let mut entries = BTreeMap::new();
+    visit(root, root, &mut entries)?;
+    Ok(entries)
+}
+
+fn clear_worktree(root: &Path) -> io::Result<()> {
+    for child in fs::read_dir(root)? {
+        let child = child?;
+        if child.file_name() == ".git" {
+            continue;
+        }
+        let path = child.path();
+        let metadata = fs::symlink_metadata(&path)?;
+        if metadata.is_dir() && !metadata.file_type().is_symlink() {
+            fs::remove_dir_all(path)?;
+        } else {
+            fs::remove_file(path)?;
+        }
+    }
+    Ok(())
+}
+
+fn restore_worktree(root: &Path, entries: &BTreeMap<PathBuf, Entry>) -> io::Result<()> {
+    for (relative, entry) in entries {
+        if matches!(entry, Entry::Directory { .. }) {
+            fs::create_dir_all(root.join(relative))?;
+        }
+    }
+    for (relative, entry) in entries {
+        let path = root.join(relative);
+        match entry {
+            Entry::Directory { .. } => {}
+            Entry::File { mode, data } => {
+                if let Some(parent) = path.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+                fs::write(&path, data)?;
+                fs::set_permissions(path, fs::Permissions::from_mode(*mode))?;
+            }
+            Entry::Symlink { target } => {
+                if let Some(parent) = path.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+                symlink(target, path)?;
+            }
+        }
+    }
+    for (relative, entry) in entries.iter().rev() {
+        if let Entry::Directory { mode } = entry {
+            fs::set_permissions(root.join(relative), fs::Permissions::from_mode(*mode))?;
+        }
+    }
+    Ok(())
+}

--- a/src/review.rs
+++ b/src/review.rs
@@ -112,15 +112,15 @@ impl ReviewTransaction {
         })
     }
 
-    pub fn execute<F>(&mut self, operation: F) -> Result<(), ReviewError>
+    pub fn execute<F, T>(&mut self, operation: F) -> Result<T, ReviewError>
     where
-        F: FnOnce() -> Result<(), ReviewError>,
+        F: FnOnce() -> Result<T, ReviewError>,
     {
         self.mutation_started = true;
         match operation() {
-            Ok(()) => {
+            Ok(value) => {
                 self.finished = true;
-                Ok(())
+                Ok(value)
             }
             Err(original) => {
                 let rollback = self.rollback();
@@ -365,6 +365,11 @@ fn scan_worktree(root: &Path) -> io::Result<BTreeMap<PathBuf, Entry>> {
                         data: fs::read(path)?,
                     },
                 );
+            } else {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("unsupported filesystem entry `{}`", relative.display()),
+                ));
             }
         }
         Ok(())

--- a/src/review.rs
+++ b/src/review.rs
@@ -1,7 +1,7 @@
 use crate::git::{run_git_command, GitCommandError};
 use std::collections::BTreeMap;
 use std::fs;
-use std::io;
+use std::io::{self, Read};
 use std::os::unix::fs::{symlink, MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
@@ -25,8 +25,16 @@ impl From<GitCommandError> for ReviewError {
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum Entry {
     Directory { mode: u32 },
-    File { mode: u32, data: Vec<u8> },
+    File { mode: u32 },
     Symlink { target: PathBuf },
+    Other { mode: u32 },
+}
+
+#[derive(Debug)]
+struct AdminFile {
+    path: PathBuf,
+    backup_name: String,
+    existed: bool,
 }
 
 pub struct ReviewTransaction {
@@ -38,6 +46,7 @@ pub struct ReviewTransaction {
     config: Vec<u8>,
     index_path: PathBuf,
     index_existed: bool,
+    admin_files: Vec<AdminFile>,
     worktree: BTreeMap<PathBuf, Entry>,
     scratch: TempDir,
     mutation_started: bool,
@@ -46,53 +55,104 @@ pub struct ReviewTransaction {
 }
 
 impl ReviewTransaction {
-    pub fn begin(verbose: bool) -> Result<Self, ReviewError> {
-        let root_output = run_git_command(
+    pub fn repository_root(verbose: bool) -> Result<PathBuf, ReviewError> {
+        let output = run_git_command(
             "locate repository worktree",
             &["rev-parse", "--show-toplevel"],
-            false,
+            &[],
             verbose,
         )?;
-        let root = PathBuf::from(String::from_utf8_lossy(&root_output.stdout).trim());
+        Ok(PathBuf::from(
+            String::from_utf8_lossy(&output.stdout).trim(),
+        ))
+    }
+
+    /// Capture all rollback state. Call this immediately before the first operation that can
+    /// change the review checkout, refs, index, config, or worktree.
+    pub fn begin(root: PathBuf, verbose: bool) -> Result<Self, ReviewError> {
         let head_oid = git_stdout("capture original HEAD", &["rev-parse", "HEAD"], verbose)?;
         let symbolic = run_git_command(
             "capture original branch",
             &["symbolic-ref", "--quiet", "HEAD"],
-            true,
+            &[1],
             verbose,
         )?;
         let head_ref = symbolic
             .status
             .success()
             .then(|| String::from_utf8_lossy(&symbolic.stdout).trim().to_string());
+        // Local branch refs are transactional state; reflogs are intentionally outside the
+        // rollback contract because Git appends to them while restoring those refs.
         let heads = read_heads(verbose)?;
         let config_path = resolve_git_path(&root, "config", verbose)?;
         let index_path = resolve_git_path(&root, "index", verbose)?;
-        let config = fs::read(&config_path).map_err(|error| {
-            ReviewError::Message(format!("failed to snapshot local config: {error}"))
-        })?;
-        let index = match fs::read(&index_path) {
-            Ok(bytes) => Some(bytes),
-            Err(error) if error.kind() == io::ErrorKind::NotFound => None,
-            Err(error) => {
-                return Err(ReviewError::Message(format!(
-                    "failed to snapshot real index: {error}"
-                )))
-            }
-        };
-        let worktree = scan_worktree(&root).map_err(|error| {
-            ReviewError::Message(format!("failed to snapshot worktree: {error}"))
+        let scratch_parent = config_path.parent().ok_or_else(|| {
+            ReviewError::Message("local Git config has no parent directory".to_string())
         })?;
         let scratch = tempfile::Builder::new()
             .prefix("cresca-review-")
-            .tempdir()
+            .tempdir_in(scratch_parent)
             .map_err(|error| {
-                ReviewError::Message(format!("failed to create scratch area: {error}"))
+                ReviewError::Message(format!(
+                    "failed to create Git-private scratch area: {error}"
+                ))
             })?;
-        if let Some(index) = &index {
-            fs::write(scratch.path().join("index"), index).map_err(|error| {
+
+        let config = fs::read(&config_path).map_err(|error| {
+            ReviewError::Message(format!("failed to snapshot local config: {error}"))
+        })?;
+        let index_existed =
+            copy_if_present(&index_path, &scratch.path().join("index")).map_err(|error| {
                 ReviewError::Message(format!("failed to back up real index: {error}"))
             })?;
+
+        let admin_names = [
+            "FETCH_HEAD",
+            "ORIG_HEAD",
+            "SQUASH_MSG",
+            "MERGE_HEAD",
+            "MERGE_MSG",
+            "MERGE_MODE",
+            "AUTO_MERGE",
+            "CHERRY_PICK_HEAD",
+            "REVERT_HEAD",
+        ];
+        let mut admin_files = Vec::new();
+        for (number, name) in admin_names.iter().enumerate() {
+            let path = resolve_git_path(&root, name, verbose)?;
+            let backup_name = format!("admin-{number}");
+            let existed =
+                copy_if_present(&path, &scratch.path().join(&backup_name)).map_err(|error| {
+                    ReviewError::Message(format!("failed to back up {name}: {error}"))
+                })?;
+            admin_files.push(AdminFile {
+                path,
+                backup_name,
+                existed,
+            });
+        }
+
+        let worktree = scan_worktree(&root).map_err(|error| {
+            ReviewError::Message(format!("failed to snapshot worktree: {error}"))
+        })?;
+        let backup_root = scratch.path().join("worktree");
+        for (relative, entry) in &worktree {
+            if matches!(entry, Entry::File { .. }) {
+                let destination = backup_root.join(relative);
+                if let Some(parent) = destination.parent() {
+                    fs::create_dir_all(parent).map_err(|error| {
+                        ReviewError::Message(format!(
+                            "failed to create worktree backup directory: {error}"
+                        ))
+                    })?;
+                }
+                fs::copy(root.join(relative), destination).map_err(|error| {
+                    ReviewError::Message(format!(
+                        "failed to stream worktree backup for `{}`: {error}",
+                        relative.display()
+                    ))
+                })?;
+            }
         }
 
         Ok(Self {
@@ -103,7 +163,8 @@ impl ReviewTransaction {
             config_path,
             config,
             index_path,
-            index_existed: index.is_some(),
+            index_existed,
+            admin_files,
             worktree,
             scratch,
             mutation_started: false,
@@ -139,7 +200,7 @@ impl ReviewTransaction {
     fn rollback(&self) -> Result<(), String> {
         let mut diagnostics = Vec::new();
         let run = |description: &str, args: &[&str]| {
-            run_git_command(description, args, false, self.verbose)
+            run_git_command(description, args, &[], self.verbose)
                 .map(|_| ())
                 .map_err(|error| format!("{description}: {error:?}"))
         };
@@ -188,36 +249,33 @@ impl ReviewTransaction {
             diagnostics.push(error);
         }
 
-        if let Err(error) =
-            clear_worktree(&self.root).and_then(|()| restore_worktree(&self.root, &self.worktree))
-        {
-            diagnostics.push(format!("restore worktree: {error}"));
-        }
+        reconcile_worktree(
+            &self.root,
+            &self.worktree,
+            &self.scratch.path().join("worktree"),
+            &mut diagnostics,
+        );
         if let Err(error) = fs::write(&self.config_path, &self.config) {
             diagnostics.push(format!("restore local config: {error}"));
         }
-        if self.index_existed {
-            match fs::read(self.scratch.path().join("index")) {
-                Ok(index) => {
-                    if let Err(error) = fs::write(&self.index_path, index) {
-                        diagnostics.push(format!("restore real index: {error}"));
-                    }
-                }
-                Err(error) => {
-                    diagnostics.push(format!("restore real index: {error}"));
-                }
-            }
-        } else {
-            match fs::remove_file(&self.index_path) {
-                Ok(()) => {}
-                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-                Err(error) => diagnostics.push(format!("remove generated real index: {error}")),
-            }
+        restore_optional_file(
+            &self.index_path,
+            &self.scratch.path().join("index"),
+            self.index_existed,
+            "real index",
+            &mut diagnostics,
+        );
+        for admin in &self.admin_files {
+            restore_optional_file(
+                &admin.path,
+                &self.scratch.path().join(&admin.backup_name),
+                admin.existed,
+                &format!("Git admin file `{}`", admin.path.display()),
+                &mut diagnostics,
+            );
         }
 
-        if let Err(error) = self.verify() {
-            diagnostics.push(error);
-        }
+        self.verify(&mut diagnostics);
         if diagnostics.is_empty() {
             Ok(())
         } else {
@@ -225,57 +283,91 @@ impl ReviewTransaction {
         }
     }
 
-    fn verify(&self) -> Result<(), String> {
-        let current_oid = git_stdout("verify restored HEAD", &["rev-parse", "HEAD"], self.verbose)
-            .map_err(|error| format!("verify HEAD: {error:?}"))?;
-        if current_oid != self.head_oid {
-            return Err(format!(
+    fn verify(&self, diagnostics: &mut Vec<String>) {
+        match git_stdout("verify restored HEAD", &["rev-parse", "HEAD"], self.verbose) {
+            Ok(current_oid) if current_oid != self.head_oid => diagnostics.push(format!(
                 "HEAD mismatch: expected {}, found {current_oid}",
                 self.head_oid
-            ));
+            )),
+            Err(error) => diagnostics.push(format!("verify HEAD: {error:?}")),
+            _ => {}
         }
-        let symbolic = run_git_command(
+        match run_git_command(
             "verify restored branch",
             &["symbolic-ref", "--quiet", "HEAD"],
-            true,
+            &[1],
             self.verbose,
-        )
-        .map_err(|error| format!("verify branch: {error:?}"))?;
-        let current_ref = symbolic
-            .status
-            .success()
-            .then(|| String::from_utf8_lossy(&symbolic.stdout).trim().to_string());
-        if current_ref != self.head_ref {
-            return Err(format!(
-                "HEAD attachment mismatch: expected {:?}, found {current_ref:?}",
-                self.head_ref
-            ));
+        ) {
+            Ok(symbolic) => {
+                let current_ref = symbolic
+                    .status
+                    .success()
+                    .then(|| String::from_utf8_lossy(&symbolic.stdout).trim().to_string());
+                if current_ref != self.head_ref {
+                    diagnostics.push(format!(
+                        "HEAD attachment mismatch: expected {:?}, found {current_ref:?}",
+                        self.head_ref
+                    ));
+                }
+            }
+            Err(error) => diagnostics.push(format!("verify branch: {error:?}")),
         }
-        let heads = read_heads(self.verbose).map_err(|error| format!("verify refs: {error:?}"))?;
-        if heads != self.heads {
-            return Err("local heads differ after rollback".to_string());
+        match read_heads(self.verbose) {
+            Ok(heads) if heads != self.heads => {
+                diagnostics.push("local heads differ after rollback".to_string())
+            }
+            Err(error) => diagnostics.push(format!("verify refs: {error:?}")),
+            _ => {}
         }
-        if fs::read(&self.config_path).map_err(|error| error.to_string())? != self.config {
-            return Err("local config differs after rollback".to_string());
+        match fs::read(&self.config_path) {
+            Ok(config) if config != self.config => {
+                diagnostics.push("local config differs after rollback".to_string())
+            }
+            Err(error) => diagnostics.push(format!("verify local config: {error}")),
+            _ => {}
         }
-        let index = match fs::read(&self.index_path) {
-            Ok(bytes) => Some(bytes),
-            Err(error) if error.kind() == io::ErrorKind::NotFound => None,
-            Err(error) => return Err(error.to_string()),
-        };
-        let expected_index = if self.index_existed {
-            Some(fs::read(self.scratch.path().join("index")).map_err(|error| error.to_string())?)
-        } else {
-            None
-        };
-        if index != expected_index {
-            return Err("real index differs after rollback".to_string());
+        verify_optional_file(
+            &self.index_path,
+            &self.scratch.path().join("index"),
+            self.index_existed,
+            "real index",
+            diagnostics,
+        );
+        for admin in &self.admin_files {
+            verify_optional_file(
+                &admin.path,
+                &self.scratch.path().join(&admin.backup_name),
+                admin.existed,
+                &format!("Git admin file `{}`", admin.path.display()),
+                diagnostics,
+            );
         }
-        let worktree = scan_worktree(&self.root).map_err(|error| error.to_string())?;
-        if worktree != self.worktree {
-            return Err("worktree differs after rollback".to_string());
+        match scan_worktree(&self.root) {
+            Ok(worktree) => {
+                if worktree != self.worktree {
+                    diagnostics.push("worktree entries differ after rollback".to_string());
+                }
+                for (relative, entry) in &self.worktree {
+                    if matches!(entry, Entry::File { .. }) {
+                        match files_equal(
+                            &self.root.join(relative),
+                            &self.scratch.path().join("worktree").join(relative),
+                        ) {
+                            Ok(true) => {}
+                            Ok(false) => diagnostics.push(format!(
+                                "worktree file content differs after rollback: `{}`",
+                                relative.display()
+                            )),
+                            Err(error) => diagnostics.push(format!(
+                                "verify worktree file `{}`: {error}",
+                                relative.display()
+                            )),
+                        }
+                    }
+                }
+            }
+            Err(error) => diagnostics.push(format!("verify worktree: {error}")),
         }
-        Ok(())
     }
 }
 
@@ -288,7 +380,7 @@ impl Drop for ReviewTransaction {
 }
 
 fn git_stdout(description: &str, args: &[&str], verbose: bool) -> Result<String, GitCommandError> {
-    let output = run_git_command(description, args, false, verbose)?;
+    let output = run_git_command(description, args, &[], verbose)?;
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
@@ -315,7 +407,7 @@ fn read_heads(verbose: bool) -> Result<BTreeMap<String, String>, GitCommandError
             "--format=%(refname) %(objectname)",
             "refs/heads/",
         ],
-        false,
+        &[],
         verbose,
     )?;
     Ok(String::from_utf8_lossy(&output.stdout)
@@ -323,6 +415,14 @@ fn read_heads(verbose: bool) -> Result<BTreeMap<String, String>, GitCommandError
         .filter_map(|line| line.split_once(' '))
         .map(|(name, oid)| (name.to_string(), oid.to_string()))
         .collect())
+}
+
+fn copy_if_present(source: &Path, destination: &Path) -> io::Result<bool> {
+    match fs::copy(source, destination) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
+    }
 }
 
 fn scan_worktree(root: &Path) -> io::Result<BTreeMap<PathBuf, Entry>> {
@@ -342,34 +442,28 @@ fn scan_worktree(root: &Path) -> io::Result<BTreeMap<PathBuf, Entry>> {
                 .expect("worktree child must be beneath root")
                 .to_path_buf();
             let metadata = fs::symlink_metadata(&path)?;
-            if metadata.file_type().is_symlink() {
-                entries.insert(
-                    relative,
-                    Entry::Symlink {
-                        target: fs::read_link(path)?,
-                    },
-                );
+            let entry = if metadata.file_type().is_symlink() {
+                Entry::Symlink {
+                    target: fs::read_link(&path)?,
+                }
             } else if metadata.is_dir() {
-                entries.insert(
-                    relative.clone(),
-                    Entry::Directory {
-                        mode: metadata.mode(),
-                    },
-                );
-                visit(root, &path, entries)?;
+                Entry::Directory {
+                    mode: metadata.mode(),
+                }
             } else if metadata.is_file() {
-                entries.insert(
-                    relative,
-                    Entry::File {
-                        mode: metadata.mode(),
-                        data: fs::read(path)?,
-                    },
-                );
+                Entry::File {
+                    mode: metadata.mode(),
+                }
             } else {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!("unsupported filesystem entry `{}`", relative.display()),
                 ));
+            };
+            let is_directory = matches!(entry, Entry::Directory { .. });
+            entries.insert(relative, entry);
+            if is_directory {
+                visit(root, &path, entries)?;
             }
         }
         Ok(())
@@ -380,52 +474,272 @@ fn scan_worktree(root: &Path) -> io::Result<BTreeMap<PathBuf, Entry>> {
     Ok(entries)
 }
 
-fn clear_worktree(root: &Path) -> io::Result<()> {
-    for child in fs::read_dir(root)? {
-        let child = child?;
-        if child.file_name() == ".git" {
-            continue;
-        }
-        let path = child.path();
-        let metadata = fs::symlink_metadata(&path)?;
-        if metadata.is_dir() && !metadata.file_type().is_symlink() {
-            fs::remove_dir_all(path)?;
-        } else {
-            fs::remove_file(path)?;
+fn scan_worktree_tolerant(root: &Path, diagnostics: &mut Vec<String>) -> BTreeMap<PathBuf, Entry> {
+    fn visit(
+        root: &Path,
+        directory: &Path,
+        entries: &mut BTreeMap<PathBuf, Entry>,
+        diagnostics: &mut Vec<String>,
+    ) {
+        let children = match fs::read_dir(directory) {
+            Ok(children) => children,
+            Err(error) => {
+                diagnostics.push(format!(
+                    "scan `{}` during rollback: {error}",
+                    directory.display()
+                ));
+                return;
+            }
+        };
+        for child in children {
+            let child = match child {
+                Ok(child) => child,
+                Err(error) => {
+                    diagnostics.push(format!("read worktree entry during rollback: {error}"));
+                    continue;
+                }
+            };
+            if directory == root && child.file_name() == ".git" {
+                continue;
+            }
+            let path = child.path();
+            let relative = match path.strip_prefix(root) {
+                Ok(relative) => relative.to_path_buf(),
+                Err(error) => {
+                    diagnostics.push(format!(
+                        "resolve rollback path `{}`: {error}",
+                        path.display()
+                    ));
+                    continue;
+                }
+            };
+            let metadata = match fs::symlink_metadata(&path) {
+                Ok(metadata) => metadata,
+                Err(error) => {
+                    diagnostics.push(format!(
+                        "inspect `{}` during rollback: {error}",
+                        relative.display()
+                    ));
+                    continue;
+                }
+            };
+            let entry = if metadata.file_type().is_symlink() {
+                match fs::read_link(&path) {
+                    Ok(target) => Entry::Symlink { target },
+                    Err(error) => {
+                        diagnostics.push(format!(
+                            "read symlink `{}` during rollback: {error}",
+                            relative.display()
+                        ));
+                        continue;
+                    }
+                }
+            } else if metadata.is_dir() {
+                Entry::Directory {
+                    mode: metadata.mode(),
+                }
+            } else if metadata.is_file() {
+                Entry::File {
+                    mode: metadata.mode(),
+                }
+            } else {
+                Entry::Other {
+                    mode: metadata.mode(),
+                }
+            };
+            let is_directory = matches!(entry, Entry::Directory { .. });
+            entries.insert(relative, entry);
+            if is_directory {
+                visit(root, &path, entries, diagnostics);
+            }
         }
     }
-    Ok(())
+
+    let mut entries = BTreeMap::new();
+    visit(root, root, &mut entries, diagnostics);
+    entries
 }
 
-fn restore_worktree(root: &Path, entries: &BTreeMap<PathBuf, Entry>) -> io::Result<()> {
-    for (relative, entry) in entries {
-        if matches!(entry, Entry::Directory { .. }) {
-            fs::create_dir_all(root.join(relative))?;
+fn remove_path(path: &Path) -> io::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {
+            fs::remove_dir_all(path)
+        }
+        Ok(_) => fs::remove_file(path),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn reconcile_worktree(
+    root: &Path,
+    expected: &BTreeMap<PathBuf, Entry>,
+    backup_root: &Path,
+    diagnostics: &mut Vec<String>,
+) {
+    let current = scan_worktree_tolerant(root, diagnostics);
+    let mut extras: Vec<_> = current
+        .keys()
+        .filter(|relative| !expected.contains_key(*relative))
+        .cloned()
+        .collect();
+    extras.sort_by_key(|path| std::cmp::Reverse(path.components().count()));
+    for relative in extras {
+        if let Err(error) = remove_path(&root.join(&relative)) {
+            diagnostics.push(format!(
+                "remove generated path `{}`: {error}",
+                relative.display()
+            ));
         }
     }
-    for (relative, entry) in entries {
+
+    for (relative, entry) in expected {
+        if let Entry::Directory { .. } = entry {
+            let path = root.join(relative);
+            if !matches!(fs::symlink_metadata(&path), Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink())
+            {
+                if let Err(error) = remove_path(&path) {
+                    diagnostics.push(format!(
+                        "replace path `{}` with directory: {error}",
+                        relative.display()
+                    ));
+                    continue;
+                }
+                if let Err(error) = fs::create_dir_all(&path) {
+                    diagnostics.push(format!(
+                        "restore directory `{}`: {error}",
+                        relative.display()
+                    ));
+                }
+            }
+        }
+    }
+    for (relative, entry) in expected {
         let path = root.join(relative);
         match entry {
-            Entry::Directory { .. } => {}
-            Entry::File { mode, data } => {
-                if let Some(parent) = path.parent() {
-                    fs::create_dir_all(parent)?;
+            Entry::Directory { .. } | Entry::Other { .. } => {}
+            Entry::File { mode } => {
+                if matches!(fs::symlink_metadata(&path), Ok(metadata) if !metadata.is_file() || metadata.file_type().is_symlink())
+                {
+                    if let Err(error) = remove_path(&path) {
+                        diagnostics.push(format!(
+                            "replace path `{}` with file: {error}",
+                            relative.display()
+                        ));
+                        continue;
+                    }
                 }
-                fs::write(&path, data)?;
-                fs::set_permissions(path, fs::Permissions::from_mode(*mode))?;
+                if let Some(parent) = path.parent() {
+                    if let Err(error) = fs::create_dir_all(parent) {
+                        diagnostics.push(format!(
+                            "create parent for `{}`: {error}",
+                            relative.display()
+                        ));
+                        continue;
+                    }
+                }
+                if let Err(error) = fs::copy(backup_root.join(relative), &path) {
+                    diagnostics.push(format!("restore file `{}`: {error}", relative.display()));
+                    continue;
+                }
+                if let Err(error) = fs::set_permissions(&path, fs::Permissions::from_mode(*mode)) {
+                    diagnostics.push(format!(
+                        "restore mode for `{}`: {error}",
+                        relative.display()
+                    ));
+                }
             }
             Entry::Symlink { target } => {
-                if let Some(parent) = path.parent() {
-                    fs::create_dir_all(parent)?;
+                if let Err(error) = remove_path(&path) {
+                    diagnostics.push(format!(
+                        "replace path `{}` with symlink: {error}",
+                        relative.display()
+                    ));
+                    continue;
                 }
-                symlink(target, path)?;
+                if let Some(parent) = path.parent() {
+                    if let Err(error) = fs::create_dir_all(parent) {
+                        diagnostics.push(format!(
+                            "create parent for `{}`: {error}",
+                            relative.display()
+                        ));
+                        continue;
+                    }
+                }
+                if let Err(error) = symlink(target, &path) {
+                    diagnostics.push(format!("restore symlink `{}`: {error}", relative.display()));
+                }
             }
         }
     }
-    for (relative, entry) in entries.iter().rev() {
+    for (relative, entry) in expected.iter().rev() {
         if let Entry::Directory { mode } = entry {
-            fs::set_permissions(root.join(relative), fs::Permissions::from_mode(*mode))?;
+            if let Err(error) =
+                fs::set_permissions(root.join(relative), fs::Permissions::from_mode(*mode))
+            {
+                diagnostics.push(format!(
+                    "restore directory mode `{}`: {error}",
+                    relative.display()
+                ));
+            }
         }
     }
-    Ok(())
+}
+
+fn restore_optional_file(
+    path: &Path,
+    backup: &Path,
+    existed: bool,
+    label: &str,
+    diagnostics: &mut Vec<String>,
+) {
+    let result = if existed {
+        fs::copy(backup, path).map(|_| ())
+    } else {
+        match fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error),
+        }
+    };
+    if let Err(error) = result {
+        diagnostics.push(format!("restore {label}: {error}"));
+    }
+}
+
+fn verify_optional_file(
+    path: &Path,
+    backup: &Path,
+    existed: bool,
+    label: &str,
+    diagnostics: &mut Vec<String>,
+) {
+    match (existed, fs::symlink_metadata(path)) {
+        (false, Err(error)) if error.kind() == io::ErrorKind::NotFound => {}
+        (false, Ok(_)) => diagnostics.push(format!("generated {label} remains after rollback")),
+        (false, Err(error)) => diagnostics.push(format!("verify {label}: {error}")),
+        (true, Err(error)) => diagnostics.push(format!("verify {label}: {error}")),
+        (true, Ok(_)) => match files_equal(path, backup) {
+            Ok(true) => {}
+            Ok(false) => diagnostics.push(format!("{label} differs after rollback")),
+            Err(error) => diagnostics.push(format!("verify {label}: {error}")),
+        },
+    }
+}
+
+fn files_equal(left: &Path, right: &Path) -> io::Result<bool> {
+    let mut left = fs::File::open(left)?;
+    let mut right = fs::File::open(right)?;
+    let mut left_buffer = [0_u8; 64 * 1024];
+    let mut right_buffer = [0_u8; 64 * 1024];
+    loop {
+        let left_count = left.read(&mut left_buffer)?;
+        let right_count = right.read(&mut right_buffer)?;
+        if left_count != right_count || left_buffer[..left_count] != right_buffer[..right_count] {
+            return Ok(false);
+        }
+        if left_count == 0 {
+            return Ok(true);
+        }
+    }
 }

--- a/src/review.rs
+++ b/src/review.rs
@@ -1,5 +1,5 @@
 use crate::git::{run_git_command, GitCommandError};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io::{self, Read};
 use std::os::unix::fs::{symlink, MetadataExt, PermissionsExt};
@@ -42,6 +42,7 @@ pub struct ReviewTransaction {
     head_ref: Option<String>,
     head_oid: String,
     heads: BTreeMap<String, String>,
+    remote_refs: BTreeMap<String, String>,
     config_path: PathBuf,
     config: Vec<u8>,
     index_path: PathBuf,
@@ -84,6 +85,7 @@ impl ReviewTransaction {
         // Local branch refs are transactional state; reflogs are intentionally outside the
         // rollback contract because Git appends to them while restoring those refs.
         let heads = read_heads(verbose)?;
+        let remote_refs = read_refs("refs/remotes/", verbose)?;
         let config_path = resolve_git_path(&root, "config", verbose)?;
         let index_path = resolve_git_path(&root, "index", verbose)?;
         let scratch_parent = config_path.parent().ok_or_else(|| {
@@ -113,9 +115,11 @@ impl ReviewTransaction {
             "MERGE_HEAD",
             "MERGE_MSG",
             "MERGE_MODE",
+            "MERGE_RR",
             "AUTO_MERGE",
             "CHERRY_PICK_HEAD",
             "REVERT_HEAD",
+            "COMMIT_EDITMSG",
         ];
         let mut admin_files = Vec::new();
         for (number, name) in admin_names.iter().enumerate() {
@@ -160,6 +164,7 @@ impl ReviewTransaction {
             head_ref,
             head_oid,
             heads,
+            remote_refs,
             config_path,
             config,
             index_path,
@@ -234,6 +239,13 @@ impl ReviewTransaction {
             }
             Err(error) => diagnostics.push(format!("read local heads for rollback: {error:?}")),
         }
+        restore_refs(
+            "remote-tracking",
+            "refs/remotes/",
+            &self.remote_refs,
+            self.verbose,
+            &mut diagnostics,
+        );
 
         let checkout_result = match &self.head_ref {
             Some(reference) => run(
@@ -319,6 +331,13 @@ impl ReviewTransaction {
             Err(error) => diagnostics.push(format!("verify refs: {error:?}")),
             _ => {}
         }
+        match read_refs("refs/remotes/", self.verbose) {
+            Ok(refs) if refs != self.remote_refs => {
+                diagnostics.push("remote-tracking refs differ after rollback".to_string())
+            }
+            Err(error) => diagnostics.push(format!("verify remote-tracking refs: {error:?}")),
+            _ => {}
+        }
         match fs::read(&self.config_path) {
             Ok(config) if config != self.config => {
                 diagnostics.push("local config differs after rollback".to_string())
@@ -399,13 +418,17 @@ fn resolve_git_path(root: &Path, name: &str, verbose: bool) -> Result<PathBuf, R
 }
 
 fn read_heads(verbose: bool) -> Result<BTreeMap<String, String>, GitCommandError> {
+    read_refs("refs/heads/", verbose)
+}
+
+fn read_refs(prefix: &str, verbose: bool) -> Result<BTreeMap<String, String>, GitCommandError> {
     let output = run_git_command(
-        "list local heads",
+        "list repository refs",
         &[
             "for-each-ref",
             "--sort=refname",
             "--format=%(refname) %(objectname)",
-            "refs/heads/",
+            prefix,
         ],
         &[],
         verbose,
@@ -415,6 +438,44 @@ fn read_heads(verbose: bool) -> Result<BTreeMap<String, String>, GitCommandError
         .filter_map(|line| line.split_once(' '))
         .map(|(name, oid)| (name.to_string(), oid.to_string()))
         .collect())
+}
+
+fn restore_refs(
+    label: &str,
+    prefix: &str,
+    expected: &BTreeMap<String, String>,
+    verbose: bool,
+    diagnostics: &mut Vec<String>,
+) {
+    let current = match read_refs(prefix, verbose) {
+        Ok(current) => current,
+        Err(error) => {
+            diagnostics.push(format!("read {label} refs for rollback: {error:?}"));
+            return;
+        }
+    };
+    for name in current.keys().filter(|name| !expected.contains_key(*name)) {
+        if let Err(error) = run_git_command(
+            &format!("remove generated {label} ref"),
+            &["update-ref", "-d", name],
+            &[],
+            verbose,
+        ) {
+            diagnostics.push(format!("remove generated {label} ref `{name}`: {error:?}"));
+        }
+    }
+    for (name, oid) in expected {
+        if current.get(name) != Some(oid) {
+            if let Err(error) = run_git_command(
+                &format!("restore {label} ref"),
+                &["update-ref", name, oid],
+                &[],
+                verbose,
+            ) {
+                diagnostics.push(format!("restore {label} ref `{name}`: {error:?}"));
+            }
+        }
+    }
 }
 
 fn copy_if_present(source: &Path, destination: &Path) -> io::Result<bool> {
@@ -583,6 +644,41 @@ fn reconcile_worktree(
         .filter(|relative| !expected.contains_key(*relative))
         .cloned()
         .collect();
+    let mismatches: Vec<_> = expected
+        .iter()
+        .filter_map(|(relative, entry)| {
+            (!entry_matches(root, relative, entry, backup_root).unwrap_or(false))
+                .then_some(relative.clone())
+        })
+        .collect();
+
+    let mut directories_to_widen = BTreeSet::new();
+    for relative in extras.iter().chain(mismatches.iter()) {
+        let mut ancestor = relative.parent();
+        while let Some(path) = ancestor {
+            if matches!(expected.get(path), Some(Entry::Directory { .. })) {
+                directories_to_widen.insert(path.to_path_buf());
+            }
+            ancestor = path.parent();
+        }
+    }
+    for relative in directories_to_widen {
+        let Some(Entry::Directory { mode }) = expected.get(&relative) else {
+            continue;
+        };
+        let widened = *mode | 0o700;
+        if widened != *mode {
+            if let Err(error) =
+                fs::set_permissions(root.join(&relative), fs::Permissions::from_mode(widened))
+            {
+                diagnostics.push(format!(
+                    "temporarily widen directory `{}` for rollback: {error}",
+                    relative.display()
+                ));
+            }
+        }
+    }
+
     extras.sort_by_key(|path| std::cmp::Reverse(path.components().count()));
     for relative in extras {
         if let Err(error) = remove_path(&root.join(&relative)) {
@@ -594,6 +690,9 @@ fn reconcile_worktree(
     }
 
     for (relative, entry) in expected {
+        if entry_matches(root, relative, entry, backup_root).unwrap_or(false) {
+            continue;
+        }
         if let Entry::Directory { .. } = entry {
             let path = root.join(relative);
             if !matches!(fs::symlink_metadata(&path), Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink())
@@ -619,6 +718,32 @@ fn reconcile_worktree(
         match entry {
             Entry::Directory { .. } | Entry::Other { .. } => {}
             Entry::File { mode } => {
+                let existing_regular = matches!(
+                    fs::symlink_metadata(&path),
+                    Ok(metadata) if metadata.is_file() && !metadata.file_type().is_symlink()
+                );
+                if existing_regular {
+                    if matches!(files_equal(&path, &backup_root.join(relative)), Ok(true)) {
+                        if let Err(error) =
+                            fs::set_permissions(&path, fs::Permissions::from_mode(*mode))
+                        {
+                            diagnostics.push(format!(
+                                "restore mode for `{}`: {error}",
+                                relative.display()
+                            ));
+                        }
+                        continue;
+                    }
+                    if let Err(error) =
+                        fs::set_permissions(&path, fs::Permissions::from_mode(*mode | 0o600))
+                    {
+                        diagnostics.push(format!(
+                            "temporarily make file `{}` writable: {error}",
+                            relative.display()
+                        ));
+                        continue;
+                    }
+                }
                 if matches!(fs::symlink_metadata(&path), Ok(metadata) if !metadata.is_file() || metadata.file_type().is_symlink())
                 {
                     if let Err(error) = remove_path(&path) {
@@ -650,6 +775,13 @@ fn reconcile_worktree(
                 }
             }
             Entry::Symlink { target } => {
+                if matches!(
+                    fs::symlink_metadata(&path),
+                    Ok(metadata) if metadata.file_type().is_symlink()
+                ) && fs::read_link(&path).ok().as_ref() == Some(target)
+                {
+                    continue;
+                }
                 if let Err(error) = remove_path(&path) {
                     diagnostics.push(format!(
                         "replace path `{}` with symlink: {error}",
@@ -683,6 +815,33 @@ fn reconcile_worktree(
                 ));
             }
         }
+    }
+}
+
+fn entry_matches(
+    root: &Path,
+    relative: &Path,
+    expected: &Entry,
+    backup_root: &Path,
+) -> io::Result<bool> {
+    let path = root.join(relative);
+    let metadata = match fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error),
+    };
+    match expected {
+        Entry::Directory { mode } => {
+            Ok(metadata.is_dir() && !metadata.file_type().is_symlink() && metadata.mode() == *mode)
+        }
+        Entry::File { mode } => Ok(metadata.is_file()
+            && !metadata.file_type().is_symlink()
+            && metadata.mode() == *mode
+            && files_equal(&path, &backup_root.join(relative))?),
+        Entry::Symlink { target } => {
+            Ok(metadata.file_type().is_symlink() && fs::read_link(path)? == *target)
+        }
+        Entry::Other { mode } => Ok(metadata.mode() == *mode),
     }
 }
 

--- a/src/review.rs
+++ b/src/review.rs
@@ -535,10 +535,15 @@ fn scan_worktree(root: &Path) -> io::Result<BTreeMap<PathBuf, Entry>> {
     Ok(entries)
 }
 
-fn scan_worktree_tolerant(root: &Path, diagnostics: &mut Vec<String>) -> BTreeMap<PathBuf, Entry> {
+fn scan_worktree_tolerant(
+    root: &Path,
+    expected: &BTreeMap<PathBuf, Entry>,
+    diagnostics: &mut Vec<String>,
+) -> BTreeMap<PathBuf, Entry> {
     fn visit(
         root: &Path,
         directory: &Path,
+        expected: &BTreeMap<PathBuf, Entry>,
         entries: &mut BTreeMap<PathBuf, Entry>,
         diagnostics: &mut Vec<String>,
     ) {
@@ -609,22 +614,31 @@ fn scan_worktree_tolerant(root: &Path, diagnostics: &mut Vec<String>) -> BTreeMa
                 }
             };
             let is_directory = matches!(entry, Entry::Directory { .. });
+            let visit_directory =
+                is_directory && matches!(expected.get(&relative), Some(Entry::Directory { .. }));
             entries.insert(relative, entry);
-            if is_directory {
-                visit(root, &path, entries, diagnostics);
+            if visit_directory {
+                visit(root, &path, expected, entries, diagnostics);
             }
         }
     }
 
     let mut entries = BTreeMap::new();
-    visit(root, root, &mut entries, diagnostics);
+    visit(root, root, expected, &mut entries, diagnostics);
     entries
 }
 
 fn remove_path(path: &Path) -> io::Result<()> {
     match fs::symlink_metadata(path) {
         Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {
-            fs::remove_dir_all(path)
+            let widened = metadata.permissions().mode() | 0o700;
+            if widened != metadata.permissions().mode() {
+                fs::set_permissions(path, fs::Permissions::from_mode(widened))?;
+            }
+            for child in fs::read_dir(path)? {
+                remove_path(&child?.path())?;
+            }
+            fs::remove_dir(path)
         }
         Ok(_) => fs::remove_file(path),
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
@@ -638,7 +652,7 @@ fn reconcile_worktree(
     backup_root: &Path,
     diagnostics: &mut Vec<String>,
 ) {
-    let current = scan_worktree_tolerant(root, diagnostics);
+    let current = scan_worktree_tolerant(root, expected, diagnostics);
     let mut extras: Vec<_> = current
         .keys()
         .filter(|relative| !expected.contains_key(*relative))
@@ -654,7 +668,7 @@ fn reconcile_worktree(
 
     let mut directories_to_widen = BTreeSet::new();
     for relative in extras.iter().chain(mismatches.iter()) {
-        let mut ancestor = relative.parent();
+        let mut ancestor = Some(relative.as_path());
         while let Some(path) = ancestor {
             if matches!(expected.get(path), Some(Entry::Directory { .. })) {
                 directories_to_widen.insert(path.to_path_buf());
@@ -662,23 +676,44 @@ fn reconcile_worktree(
             ancestor = path.parent();
         }
     }
+    let mut deferred_directory_modes = BTreeMap::new();
     for relative in directories_to_widen {
         let Some(Entry::Directory { mode }) = expected.get(&relative) else {
             continue;
         };
         let widened = *mode | 0o700;
-        if widened != *mode {
-            if let Err(error) =
-                fs::set_permissions(root.join(&relative), fs::Permissions::from_mode(widened))
-            {
-                diagnostics.push(format!(
-                    "temporarily widen directory `{}` for rollback: {error}",
-                    relative.display()
-                ));
+        let current_mode = fs::symlink_metadata(root.join(&relative))
+            .ok()
+            .filter(|metadata| metadata.is_dir() && !metadata.file_type().is_symlink())
+            .map(|metadata| metadata.mode());
+        let ready_for_descendants = match current_mode {
+            Some(current) if current == widened => true,
+            Some(_) => {
+                if let Err(error) =
+                    fs::set_permissions(root.join(&relative), fs::Permissions::from_mode(widened))
+                {
+                    diagnostics.push(format!(
+                        "temporarily widen directory `{}` for rollback: {error}",
+                        relative.display()
+                    ));
+                    false
+                } else {
+                    true
+                }
             }
+            None => false,
+        };
+        if ready_for_descendants && widened != *mode {
+            deferred_directory_modes.insert(relative, *mode);
         }
     }
 
+    let current = scan_worktree_tolerant(root, expected, diagnostics);
+    extras = current
+        .keys()
+        .filter(|relative| !expected.contains_key(*relative))
+        .cloned()
+        .collect();
     extras.sort_by_key(|path| std::cmp::Reverse(path.components().count()));
     for relative in extras {
         if let Err(error) = remove_path(&root.join(&relative)) {
@@ -693,10 +728,21 @@ fn reconcile_worktree(
         if entry_matches(root, relative, entry, backup_root).unwrap_or(false) {
             continue;
         }
-        if let Entry::Directory { .. } = entry {
+        if let Entry::Directory { mode } = entry {
             let path = root.join(relative);
-            if !matches!(fs::symlink_metadata(&path), Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink())
+            if matches!(fs::symlink_metadata(&path), Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink())
             {
+                if !deferred_directory_modes.contains_key(relative) {
+                    if let Err(error) =
+                        fs::set_permissions(&path, fs::Permissions::from_mode(*mode))
+                    {
+                        diagnostics.push(format!(
+                            "restore directory mode `{}`: {error}",
+                            relative.display()
+                        ));
+                    }
+                }
+            } else {
                 if let Err(error) = remove_path(&path) {
                     diagnostics.push(format!(
                         "replace path `{}` with directory: {error}",
@@ -709,6 +755,8 @@ fn reconcile_worktree(
                         "restore directory `{}`: {error}",
                         relative.display()
                     ));
+                } else {
+                    deferred_directory_modes.insert(relative.clone(), *mode);
                 }
             }
         }
@@ -718,6 +766,7 @@ fn reconcile_worktree(
         match entry {
             Entry::Directory { .. } | Entry::Other { .. } => {}
             Entry::File { mode } => {
+                let mut widened_existing_file = false;
                 let existing_regular = matches!(
                     fs::symlink_metadata(&path),
                     Ok(metadata) if metadata.is_file() && !metadata.file_type().is_symlink()
@@ -743,6 +792,7 @@ fn reconcile_worktree(
                         ));
                         continue;
                     }
+                    widened_existing_file = true;
                 }
                 if matches!(fs::symlink_metadata(&path), Ok(metadata) if !metadata.is_file() || metadata.file_type().is_symlink())
                 {
@@ -760,12 +810,21 @@ fn reconcile_worktree(
                             "create parent for `{}`: {error}",
                             relative.display()
                         ));
+                        if widened_existing_file {
+                            if let Err(error) =
+                                fs::set_permissions(&path, fs::Permissions::from_mode(*mode))
+                            {
+                                diagnostics.push(format!(
+                                    "restore mode for `{}`: {error}",
+                                    relative.display()
+                                ));
+                            }
+                        }
                         continue;
                     }
                 }
                 if let Err(error) = fs::copy(backup_root.join(relative), &path) {
                     diagnostics.push(format!("restore file `{}`: {error}", relative.display()));
-                    continue;
                 }
                 if let Err(error) = fs::set_permissions(&path, fs::Permissions::from_mode(*mode)) {
                     diagnostics.push(format!(
@@ -804,16 +863,14 @@ fn reconcile_worktree(
             }
         }
     }
-    for (relative, entry) in expected.iter().rev() {
-        if let Entry::Directory { mode } = entry {
-            if let Err(error) =
-                fs::set_permissions(root.join(relative), fs::Permissions::from_mode(*mode))
-            {
-                diagnostics.push(format!(
-                    "restore directory mode `{}`: {error}",
-                    relative.display()
-                ));
-            }
+    for (relative, mode) in deferred_directory_modes.iter().rev() {
+        if let Err(error) =
+            fs::set_permissions(root.join(relative), fs::Permissions::from_mode(*mode))
+        {
+            diagnostics.push(format!(
+                "restore directory mode `{}`: {error}",
+                relative.display()
+            ));
         }
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use tempfile::TempDir;
@@ -15,10 +16,12 @@ pub struct RepoState {
     pub branch: String,
     pub head: String,
     pub local_heads: Vec<u8>,
-    pub local_config: Vec<u8>,
     pub status: Vec<u8>,
     pub cached_diff: Vec<u8>,
     pub worktree_diff: Vec<u8>,
+    pub raw_local_config: Vec<u8>,
+    pub raw_index: Vec<u8>,
+    pub directories: BTreeSet<PathBuf>,
 }
 
 impl TempGitRepo {
@@ -85,6 +88,22 @@ impl TempGitRepo {
             .current_dir(self.path())
             .output()
             .expect("Failed to execute git command")
+    }
+
+    fn git_without_optional_locks(&self, args: &[&str]) -> Output {
+        let output = Command::new("git")
+            .args(args)
+            .env("GIT_OPTIONAL_LOCKS", "0")
+            .current_dir(self.path())
+            .output()
+            .expect("Failed to execute git command without optional locks");
+        assert!(
+            output.status.success(),
+            "Git command failed: git {}\nstderr: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        output
     }
 
     /// Runs a git command and returns normalized UTF-8 stdout.
@@ -198,36 +217,88 @@ impl TempGitRepo {
 
     /// Returns the real index file contents without interpreting them.
     pub fn real_index_bytes(&self) -> Vec<u8> {
-        let index_path = PathBuf::from(self.git_stdout(&["rev-parse", "--git-path", "index"]));
-        let index_path = if index_path.is_absolute() {
-            index_path
+        std::fs::read(self.git_path("index")).expect("real git index should be readable")
+    }
+
+    /// Returns the local config file contents without Git normalization.
+    pub fn raw_local_config_bytes(&self) -> Vec<u8> {
+        std::fs::read(self.git_path("config")).expect("local Git config should be readable")
+    }
+
+    /// Returns every worktree directory, including empty directories.
+    pub fn directory_set(&self) -> BTreeSet<PathBuf> {
+        fn visit(root: &Path, directory: &Path, result: &mut BTreeSet<PathBuf>) {
+            for child in
+                std::fs::read_dir(directory).expect("worktree directory should be readable")
+            {
+                let child = child.expect("worktree entry should be readable");
+                if directory == root && child.file_name() == ".git" {
+                    continue;
+                }
+                let path = child.path();
+                let metadata = std::fs::symlink_metadata(&path)
+                    .expect("worktree entry metadata should be readable");
+                if metadata.is_dir() && !metadata.file_type().is_symlink() {
+                    let relative = path
+                        .strip_prefix(root)
+                        .expect("worktree directory must be under root")
+                        .to_path_buf();
+                    result.insert(relative);
+                    visit(root, &path, result);
+                }
+            }
+        }
+
+        let mut result = BTreeSet::new();
+        visit(self.path(), self.path(), &mut result);
+        result
+    }
+
+    fn git_path(&self, name: &str) -> PathBuf {
+        let path = PathBuf::from(self.git_stdout(&["rev-parse", "--git-path", name]));
+        if path.is_absolute() {
+            path
         } else {
-            self.path().join(index_path)
-        };
-        std::fs::read(index_path).expect("real git index should be readable")
+            self.path().join(path)
+        }
     }
 
     /// Captures the repository state used by integration-test assertions.
     pub fn snapshot(&self) -> RepoState {
+        let branch = self.current_branch();
+        let head = self.rev_parse("HEAD");
+        let local_heads = self
+            .git(&[
+                "for-each-ref",
+                "--sort=refname",
+                "--format=%(refname) %(objectname)",
+                "refs/heads/",
+            ])
+            .stdout;
+        let status = self
+            .git_without_optional_locks(&[
+                "status",
+                "--porcelain=v1",
+                "-z",
+                "--untracked-files=all",
+            ])
+            .stdout;
+        let cached_diff = self.cached_diff();
+        let worktree_diff = self.worktree_diff();
+        let raw_local_config = self.raw_local_config_bytes();
+        let raw_index = self.real_index_bytes();
+        let directories = self.directory_set();
+
         RepoState {
-            branch: self.current_branch(),
-            head: self.rev_parse("HEAD"),
-            local_heads: self
-                .git(&[
-                    "for-each-ref",
-                    "--sort=refname",
-                    "--format=%(refname) %(objectname)",
-                    "refs/heads/",
-                ])
-                .stdout,
-            local_config: self
-                .git(&["config", "--local", "--null", "--list", "--show-origin"])
-                .stdout,
-            status: self
-                .git(&["status", "--porcelain=v1", "-z", "--untracked-files=all"])
-                .stdout,
-            cached_diff: self.cached_diff(),
-            worktree_diff: self.worktree_diff(),
+            branch,
+            head,
+            local_heads,
+            status,
+            cached_diff,
+            worktree_diff,
+            raw_local_config,
+            raw_index,
+            directories,
         }
     }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,5 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
+use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use tempfile::TempDir;
@@ -22,6 +23,15 @@ pub struct RepoState {
     pub raw_local_config: Vec<u8>,
     pub raw_index: Vec<u8>,
     pub directories: BTreeSet<PathBuf>,
+    pub direct_worktree: BTreeMap<PathBuf, WorktreeEntryState>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum WorktreeEntryState {
+    Directory { mode: u32 },
+    File { mode: u32, bytes: Vec<u8> },
+    Symlink { target: PathBuf },
+    Other { mode: u32 },
 }
 
 impl TempGitRepo {
@@ -254,7 +264,68 @@ impl TempGitRepo {
         result
     }
 
-    fn git_path(&self, name: &str) -> PathBuf {
+    /// Captures direct filesystem state, including ignored entries Git diffs cannot observe.
+    pub fn direct_worktree_state(&self) -> BTreeMap<PathBuf, WorktreeEntryState> {
+        fn visit(
+            root: &Path,
+            directory: &Path,
+            result: &mut BTreeMap<PathBuf, WorktreeEntryState>,
+        ) {
+            for child in
+                std::fs::read_dir(directory).expect("worktree directory should be readable")
+            {
+                let child = child.expect("worktree entry should be readable");
+                if directory == root && child.file_name() == ".git" {
+                    continue;
+                }
+                let path = child.path();
+                let relative = path
+                    .strip_prefix(root)
+                    .expect("worktree entry must be under root")
+                    .to_path_buf();
+                let metadata = std::fs::symlink_metadata(&path)
+                    .expect("worktree entry metadata should be readable");
+                let entry = if metadata.file_type().is_symlink() {
+                    WorktreeEntryState::Symlink {
+                        target: std::fs::read_link(&path)
+                            .expect("worktree symlink target should be readable"),
+                    }
+                } else if metadata.is_dir() {
+                    WorktreeEntryState::Directory {
+                        mode: metadata.mode(),
+                    }
+                } else if metadata.is_file() {
+                    WorktreeEntryState::File {
+                        mode: metadata.mode(),
+                        bytes: std::fs::read(&path).expect("worktree file should be readable"),
+                    }
+                } else {
+                    assert!(
+                        metadata.file_type().is_fifo()
+                            || metadata.file_type().is_socket()
+                            || metadata.file_type().is_block_device()
+                            || metadata.file_type().is_char_device(),
+                        "unexpected worktree entry type: {}",
+                        relative.display()
+                    );
+                    WorktreeEntryState::Other {
+                        mode: metadata.mode(),
+                    }
+                };
+                let recurse = matches!(entry, WorktreeEntryState::Directory { .. });
+                result.insert(relative, entry);
+                if recurse {
+                    visit(root, &path, result);
+                }
+            }
+        }
+
+        let mut result = BTreeMap::new();
+        visit(self.path(), self.path(), &mut result);
+        result
+    }
+
+    pub fn git_path(&self, name: &str) -> PathBuf {
         let path = PathBuf::from(self.git_stdout(&["rev-parse", "--git-path", name]));
         if path.is_absolute() {
             path
@@ -288,6 +359,7 @@ impl TempGitRepo {
         let raw_local_config = self.raw_local_config_bytes();
         let raw_index = self.real_index_bytes();
         let directories = self.directory_set();
+        let direct_worktree = self.direct_worktree_state();
 
         RepoState {
             branch,
@@ -299,6 +371,7 @@ impl TempGitRepo {
             raw_local_config,
             raw_index,
             directories,
+            direct_worktree,
         }
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,7 +2,7 @@ mod common;
 
 use common::TempGitRepo;
 use std::collections::BTreeSet;
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{FileTypeExt, PermissionsExt};
 
 fn install_git_wrapper(repo: &TempGitRepo, script: &str) -> tempfile::TempDir {
     let wrapper_dir = tempfile::TempDir::new().expect("wrapper directory should be created");
@@ -63,11 +63,8 @@ fn test_git_failure_renders_description_args_status_stdout_and_stderr() {
     assert_eq!(output.status.code(), Some(1));
     assert!(output.stdout.is_empty());
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("check working directory status"),
-        "{stderr}"
-    );
-    assert!(stderr.contains("status --porcelain"), "{stderr}");
+    assert!(stderr.contains("locate repository worktree"), "{stderr}");
+    assert!(stderr.contains("rev-parse --show-toplevel"), "{stderr}");
     assert!(stderr.contains("exit status: 42"), "{stderr}");
     assert!(stderr.contains("captured stdout"), "{stderr}");
     assert!(stderr.contains("captured stderr"), "{stderr}");
@@ -91,6 +88,74 @@ fn test_review_ref_update_failure_rolls_back_exact_repository_state() {
     assert_eq!(repo.snapshot(), before);
     assert!(!repo.ref_exists("refs/heads/review-main-develop"));
     assert!(!repo.path().join("generated-by-failed-review").exists());
+}
+
+#[test]
+fn test_post_transaction_status_failure_rolls_back_new_review_exactly() {
+    let (repo, _) = setup_linear_range();
+    let before = repo.snapshot();
+    let wrapper = install_git_wrapper(
+        &repo,
+        "#!/bin/sh\nif [ \"$1\" = status ] && [ \"$2\" = --porcelain ]; then\n  count_file=\"$0.count\"\n  count=0\n  if [ -f \"$count_file\" ]; then IFS= read -r count < \"$count_file\"; fi\n  count=$((count + 1))\n  printf '%s\\n' \"$count\" > \"$count_file\"\n  if [ \"$count\" -eq 2 ]; then\n    printf 'injected post-transaction status failure\\n' >&2\n    exit 52\n  fi\nfi\nexec \"$CRESCA_REAL_GIT\" \"$@\"\n",
+    );
+
+    let output = run_cresca_with_git_wrapper(&repo, &wrapper, &["review", "main", "develop"]);
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("check working directory status"));
+    assert_eq!(repo.snapshot(), before);
+    assert!(!repo.ref_exists("refs/heads/review-main-develop"));
+    assert_eq!(
+        repo.review_metadata_values("review-main-develop"),
+        (Vec::new(), Vec::new(), Vec::new())
+    );
+    assert!(repo.review_scope_values("review-main-develop").is_empty());
+}
+
+#[test]
+fn test_review_rejects_unsupported_fifo_before_mutation_and_preserves_it() {
+    let (repo, _) = setup_linear_range();
+    repo.write_file(".gitignore", "review.pipe\n");
+    repo.git(&["add", ".gitignore"]);
+    repo.commit("Ignore review FIFO fixture");
+    repo.git(&["push", "origin", "main"]);
+    let fifo_path = repo.path().join("review.pipe");
+    let mkfifo = std::process::Command::new("mkfifo")
+        .arg(&fifo_path)
+        .output()
+        .expect("mkfifo should be executable");
+    assert!(
+        mkfifo.status.success(),
+        "mkfifo failed: {}",
+        String::from_utf8_lossy(&mkfifo.stderr)
+    );
+    let before = repo.snapshot();
+    let wrapper = install_git_wrapper(
+        &repo,
+        "#!/bin/sh\nif [ \"$1\" = checkout ] && [ \"$2\" = -b ]; then\n  \"$CRESCA_REAL_GIT\" \"$@\" || exit $?\n  printf 'mutation should not be reached\\n' >&2\n  exit 53\nfi\nexec \"$CRESCA_REAL_GIT\" \"$@\"\n",
+    );
+
+    let output = run_cresca_with_git_wrapper(&repo, &wrapper, &["review", "main", "develop"]);
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("unsupported filesystem entry"),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(repo.snapshot(), before);
+    assert!(
+        std::fs::symlink_metadata(&fifo_path)
+            .expect("pre-existing FIFO must survive")
+            .file_type()
+            .is_fifo(),
+        "pre-existing FIFO should remain a FIFO"
+    );
+    assert!(!repo.ref_exists("refs/heads/review-main-develop"));
+    assert_eq!(
+        repo.review_metadata_values("review-main-develop"),
+        (Vec::new(), Vec::new(), Vec::new())
+    );
 }
 
 #[test]
@@ -124,6 +189,8 @@ fn test_review_config_failure_removes_partial_identity_scope_and_restores_config
 #[test]
 fn test_review_materialization_failure_restores_index_worktree_and_generated_paths() {
     let (repo, _) = setup_linear_range();
+    std::fs::create_dir_all(repo.path().join("pre-existing-empty/nested"))
+        .expect("empty directory fixture should be created");
     let before = repo.snapshot();
     let wrapper = install_git_wrapper(
         &repo,
@@ -136,6 +203,24 @@ fn test_review_materialization_failure_restores_index_worktree_and_generated_pat
     assert!(String::from_utf8_lossy(&output.stderr).contains("unstage changes for review"));
     assert_eq!(repo.snapshot(), before);
     assert!(!repo.path().join("generated-after-materialization").exists());
+}
+
+#[test]
+fn test_repository_snapshot_includes_raw_config_index_and_empty_directories() {
+    let repo = TempGitRepo::new();
+    std::fs::create_dir_all(repo.path().join("empty/also-empty"))
+        .expect("empty directory fixture should be created");
+
+    let snapshot = repo.snapshot();
+
+    assert_eq!(snapshot.raw_local_config, repo.raw_local_config_bytes());
+    assert_eq!(snapshot.raw_index, repo.real_index_bytes());
+    assert!(snapshot
+        .directories
+        .contains(&std::path::PathBuf::from("empty")));
+    assert!(snapshot
+        .directories
+        .contains(&std::path::PathBuf::from("empty/also-empty")));
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,6 +2,206 @@ mod common;
 
 use common::TempGitRepo;
 use std::collections::BTreeSet;
+use std::os::unix::fs::PermissionsExt;
+
+fn install_git_wrapper(repo: &TempGitRepo, script: &str) -> tempfile::TempDir {
+    let wrapper_dir = tempfile::TempDir::new().expect("wrapper directory should be created");
+    let wrapper_path = wrapper_dir.path().join("git");
+    std::fs::write(&wrapper_path, script).expect("git wrapper should be written");
+    let mut permissions = std::fs::metadata(&wrapper_path)
+        .expect("git wrapper metadata should be readable")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&wrapper_path, permissions).expect("git wrapper should be executable");
+    assert!(repo.path().exists());
+    wrapper_dir
+}
+
+fn real_git_path() -> String {
+    let output = std::process::Command::new("sh")
+        .args(["-c", "command -v git"])
+        .output()
+        .expect("shell should locate git");
+    assert!(output.status.success(), "git should be available on PATH");
+    String::from_utf8(output.stdout)
+        .expect("git path should be UTF-8")
+        .trim()
+        .to_string()
+}
+
+fn run_cresca_with_git_wrapper(
+    repo: &TempGitRepo,
+    wrapper: &tempfile::TempDir,
+    args: &[&str],
+) -> std::process::Output {
+    std::process::Command::new(TempGitRepo::cresca_binary())
+        .args(args)
+        .env("NO_COLOR", "1")
+        .env("PATH", wrapper.path())
+        .env("CRESCA_REAL_GIT", real_git_path())
+        .current_dir(repo.path())
+        .output()
+        .expect("Failed to execute cresca")
+}
+
+#[test]
+fn test_git_failure_renders_description_args_status_stdout_and_stderr() {
+    let repo = TempGitRepo::new();
+    let wrapper = install_git_wrapper(
+        &repo,
+        "#!/bin/sh\nprintf 'captured stdout\\n'\nprintf 'captured stderr\\n' >&2\nexit 42\n",
+    );
+
+    let output = std::process::Command::new(TempGitRepo::cresca_binary())
+        .args(["review", "main", "develop"])
+        .env("NO_COLOR", "1")
+        .env("PATH", wrapper.path())
+        .current_dir(repo.path())
+        .output()
+        .expect("Failed to execute cresca");
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("check working directory status"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("status --porcelain"), "{stderr}");
+    assert!(stderr.contains("exit status: 42"), "{stderr}");
+    assert!(stderr.contains("captured stdout"), "{stderr}");
+    assert!(stderr.contains("captured stderr"), "{stderr}");
+}
+
+#[test]
+fn test_review_ref_update_failure_rolls_back_exact_repository_state() {
+    let (repo, _) = setup_linear_range();
+    let before = repo.snapshot();
+    let wrapper = install_git_wrapper(
+        &repo,
+        "#!/bin/sh\nif [ \"$1\" = checkout ] && [ \"$2\" = -b ]; then\n  \"$CRESCA_REAL_GIT\" \"$@\" || exit $?\n  mkdir generated-by-failed-review\n  printf 'generated content\\n' > generated-by-failed-review/file.txt\n  printf 'injected ref update failure\\n' >&2\n  exit 47\nfi\nexec \"$CRESCA_REAL_GIT\" \"$@\"\n",
+    );
+
+    let output = run_cresca_with_git_wrapper(&repo, &wrapper, &["review", "main", "develop"]);
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("create review branch from merge-base")
+    );
+    assert_eq!(repo.snapshot(), before);
+    assert!(!repo.ref_exists("refs/heads/review-main-develop"));
+    assert!(!repo.path().join("generated-by-failed-review").exists());
+}
+
+#[test]
+fn test_review_config_failure_removes_partial_identity_scope_and_restores_config_exactly() {
+    let (repo, _) = setup_linear_range();
+    repo.git(&["config", "--local", "--add", "test.duplicate", "first"]);
+    repo.git(&["config", "--local", "--add", "test.duplicate", "second"]);
+    let before = repo.snapshot();
+    let wrapper = install_git_wrapper(
+        &repo,
+        "#!/bin/sh\ncase \"$*\" in\n  *'config --local --replace-all branch.review-main-develop.cresca-source'*)\n    \"$CRESCA_REAL_GIT\" \"$@\" || exit $?\n    printf 'partial config stdout\\n'\n    printf 'injected config failure\\n' >&2\n    exit 48\n    ;;\nesac\nexec \"$CRESCA_REAL_GIT\" \"$@\"\n",
+    );
+
+    let output = run_cresca_with_git_wrapper(&repo, &wrapper, &["review", "main", "develop"]);
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("record review source"));
+    assert_eq!(repo.snapshot(), before);
+    assert!(!repo.ref_exists("refs/heads/review-main-develop"));
+    assert_eq!(
+        repo.review_metadata_values("review-main-develop"),
+        (Vec::new(), Vec::new(), Vec::new())
+    );
+    assert!(repo.review_scope_values("review-main-develop").is_empty());
+    assert_eq!(
+        repo.git_config_values("test.duplicate"),
+        vec!["first", "second"]
+    );
+}
+
+#[test]
+fn test_review_materialization_failure_restores_index_worktree_and_generated_paths() {
+    let (repo, _) = setup_linear_range();
+    let before = repo.snapshot();
+    let wrapper = install_git_wrapper(
+        &repo,
+        "#!/bin/sh\nif [ \"$1\" = reset ]; then\n  \"$CRESCA_REAL_GIT\" \"$@\" || exit $?\n  mkdir generated-after-materialization\n  printf 'generated content\\n' > generated-after-materialization/file.txt\n  printf 'injected materialization failure\\n' >&2\n  exit 49\nfi\nexec \"$CRESCA_REAL_GIT\" \"$@\"\n",
+    );
+
+    let output = run_cresca_with_git_wrapper(&repo, &wrapper, &["review", "main", "develop"]);
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("unstage changes for review"));
+    assert_eq!(repo.snapshot(), before);
+    assert!(!repo.path().join("generated-after-materialization").exists());
+}
+
+#[test]
+fn test_failed_rereview_restores_previous_review_and_status_remains_usable() {
+    let (repo, range) = setup_linear_range();
+    assert!(repo
+        .run_cresca(&["review", "main", "develop", "--stop-at", &range.c[..8]])
+        .status
+        .success());
+    repo.git(&["add", "-A"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+    let before = repo.snapshot();
+    let old_scope = repo.review_scope_values("review-main-develop");
+    let wrapper = install_git_wrapper(
+        &repo,
+        "#!/bin/sh\ncase \"$*\" in\n  *'config --local --replace-all branch.review-main-develop.cresca-scope'*)\n    \"$CRESCA_REAL_GIT\" \"$@\" || exit $?\n    printf 'injected rereview scope failure\\n' >&2\n    exit 50\n    ;;\nesac\nexec \"$CRESCA_REAL_GIT\" \"$@\"\n",
+    );
+
+    let output = run_cresca_with_git_wrapper(
+        &repo,
+        &wrapper,
+        &["review", "main", "develop", "--stop-at", &range.d[..8]],
+    );
+
+    assert!(!output.status.success());
+    assert_eq!(repo.snapshot(), before);
+    assert_eq!(repo.review_scope_values("review-main-develop"), old_scope);
+    let status = repo.run_cresca(&["status"]);
+    assert!(
+        status.status.success(),
+        "restored status failed: {}",
+        String::from_utf8_lossy(&status.stderr)
+    );
+    assert!(String::from_utf8_lossy(&status.stdout).contains("current range"));
+}
+
+#[test]
+fn test_review_failure_cleans_transaction_scratch_directory() {
+    let (repo, _) = setup_linear_range();
+    let scratch_parent = tempfile::TempDir::new().expect("scratch parent should be created");
+    let wrapper = install_git_wrapper(
+        &repo,
+        "#!/bin/sh\nif [ \"$1\" = checkout ] && [ \"$2\" = -b ]; then\n  \"$CRESCA_REAL_GIT\" \"$@\" || exit $?\n  printf 'injected scratch cleanup failure\\n' >&2\n  exit 51\nfi\nexec \"$CRESCA_REAL_GIT\" \"$@\"\n",
+    );
+
+    let output = std::process::Command::new(TempGitRepo::cresca_binary())
+        .args(["review", "main", "develop"])
+        .env("NO_COLOR", "1")
+        .env("PATH", wrapper.path())
+        .env("CRESCA_REAL_GIT", real_git_path())
+        .env("TMPDIR", scratch_parent.path())
+        .current_dir(repo.path())
+        .output()
+        .expect("Failed to execute cresca");
+
+    assert!(!output.status.success());
+    let cresca_scratch: Vec<_> = std::fs::read_dir(scratch_parent.path())
+        .expect("scratch parent should remain readable")
+        .map(|entry| entry.expect("scratch entry should be readable").file_name())
+        .filter(|name| name.to_string_lossy().starts_with("cresca-review-"))
+        .collect();
+    assert!(
+        cresca_scratch.is_empty(),
+        "transaction scratch directory must be removed by RAII: {cresca_scratch:?}"
+    );
+}
 
 struct RemoveFileOnDrop(std::path::PathBuf);
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,9 +1,9 @@
 mod common;
 
 use common::TempGitRepo;
-use std::collections::BTreeSet;
-use std::os::unix::fs::{FileTypeExt, PermissionsExt};
-use std::path::Path;
+use std::collections::{BTreeMap, BTreeSet};
+use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
+use std::path::{Path, PathBuf};
 
 fn install_git_wrapper(repo: &TempGitRepo, script: &str) -> tempfile::TempDir {
     let wrapper_dir = tempfile::TempDir::new().expect("wrapper directory should be created");
@@ -73,6 +73,63 @@ fn add_ignored_paths(repo: &TempGitRepo, patterns: &str) {
     repo.git(&["push", "origin", "main"]);
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum TreeEntry {
+    Directory(u32),
+    File(u32, Vec<u8>),
+    Symlink(PathBuf),
+}
+
+fn snapshot_tree(root: &Path) -> BTreeMap<PathBuf, TreeEntry> {
+    fn visit(root: &Path, directory: &Path, entries: &mut BTreeMap<PathBuf, TreeEntry>) {
+        for child in std::fs::read_dir(directory).expect("snapshot directory should be readable") {
+            let child = child.expect("snapshot entry should be readable");
+            let path = child.path();
+            let relative = path
+                .strip_prefix(root)
+                .expect("snapshot entry should be below root")
+                .to_path_buf();
+            let metadata = std::fs::symlink_metadata(&path)
+                .expect("snapshot entry metadata should be readable");
+            if metadata.file_type().is_symlink() {
+                entries.insert(
+                    relative,
+                    TreeEntry::Symlink(
+                        std::fs::read_link(path).expect("snapshot symlink should be readable"),
+                    ),
+                );
+            } else if metadata.is_dir() {
+                entries.insert(relative, TreeEntry::Directory(metadata.mode()));
+                visit(root, &path, entries);
+            } else {
+                entries.insert(
+                    relative,
+                    TreeEntry::File(
+                        metadata.mode(),
+                        std::fs::read(path).expect("snapshot file should be readable"),
+                    ),
+                );
+            }
+        }
+    }
+
+    let mut entries = BTreeMap::new();
+    if root.exists() {
+        visit(root, root, &mut entries);
+    }
+    entries
+}
+
+struct RestoreDirectoryMode {
+    path: PathBuf,
+}
+
+impl Drop for RestoreDirectoryMode {
+    fn drop(&mut self) {
+        let _ = std::fs::set_permissions(&self.path, std::fs::Permissions::from_mode(0o755));
+    }
+}
+
 #[test]
 fn test_dirty_review_rejects_before_scanning_ignored_fifo() {
     let (repo, _) = setup_linear_range();
@@ -107,6 +164,7 @@ fn test_tmpdir_inside_worktree_does_not_endanger_transaction_backup() {
     add_ignored_paths(&repo, ".scratch/\n");
     let scratch_parent = repo.path().join(".scratch");
     std::fs::create_dir(&scratch_parent).expect("in-worktree TMPDIR should be created");
+    repo.write_file(".scratch/sentinel.txt", "user TMPDIR sentinel\n");
     let before = repo.snapshot();
     let wrapper = install_git_wrapper(
         &repo,
@@ -124,13 +182,27 @@ fn test_tmpdir_inside_worktree_does_not_endanger_transaction_backup() {
         .expect("Failed to execute cresca");
 
     assert!(!output.status.success());
-    assert_eq!(repo.snapshot(), before);
+    let after = repo.snapshot();
+    assert_eq!(after.branch, before.branch);
+    assert_eq!(after.head, before.head);
+    assert_eq!(after.local_heads, before.local_heads);
+    assert_eq!(after.status, before.status);
+    assert_eq!(after.cached_diff, before.cached_diff);
+    assert_eq!(after.worktree_diff, before.worktree_diff);
+    assert_eq!(after.raw_local_config, before.raw_local_config);
+    assert_eq!(after.raw_index, before.raw_index);
+    assert_eq!(
+        repo.read_file(".scratch/sentinel.txt"),
+        "user TMPDIR sentinel\n"
+    );
+    let cresca_scratch: Vec<_> = std::fs::read_dir(&scratch_parent)
+        .expect("in-worktree TMPDIR should remain")
+        .map(|entry| entry.expect("TMPDIR entry should be readable").file_name())
+        .filter(|name| name.to_string_lossy().starts_with("cresca-review-"))
+        .collect();
     assert!(
-        std::fs::read_dir(&scratch_parent)
-            .expect("in-worktree TMPDIR should remain")
-            .next()
-            .is_none(),
-        "transaction scratch must be cleaned without deleting its parent"
+        cresca_scratch.is_empty(),
+        "transaction backup must not be placed in ambient TMPDIR: {cresca_scratch:?}"
     );
 }
 
@@ -309,6 +381,302 @@ fn test_partial_reconcile_failure_still_restores_independent_paths() {
         "{stderr}"
     );
     assert_eq!(repo.read_file("a-restore.txt"), "must be restored\n");
+}
+
+#[test]
+fn test_successful_review_publishes_fetched_source_for_status_all() {
+    let (repo, _) = setup_linear_range();
+    let stale_source = repo.rev_parse("refs/remotes/origin/develop");
+    repo.switch_branch("develop");
+    repo.write_file("advanced-source.txt", "advanced remote source\n");
+    repo.git(&["add", "advanced-source.txt"]);
+    repo.commit("Advance source after tracking ref became stale");
+    let advanced_source = repo.rev_parse("HEAD");
+    repo.git(&["push", "origin", "develop"]);
+    repo.git(&["update-ref", "refs/remotes/origin/develop", &stale_source]);
+    repo.switch_branch("main");
+
+    let review = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        review.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&review.stdout),
+        String::from_utf8_lossy(&review.stderr)
+    );
+    assert_eq!(
+        repo.rev_parse("refs/remotes/origin/develop"),
+        advanced_source,
+        "successful review must publish the source fetched during preflight"
+    );
+    let all = run_status_stdout(&repo, &["status", "--all"]);
+    assert!(all.contains("    - advanced-source.txt\n"), "{all}");
+}
+
+#[test]
+fn test_tracking_ref_publication_failure_rolls_back_exact_state() {
+    let (repo, _) = setup_linear_range();
+    let before = repo.snapshot();
+    let before_target = repo.rev_parse("refs/remotes/origin/main");
+    let before_source = repo.rev_parse("refs/remotes/origin/develop");
+    let wrapper = install_git_wrapper(
+        &repo,
+        "#!/bin/sh\nif [ \"$1\" = update-ref ] && [ \"$2\" = refs/remotes/origin/develop ]; then\n  \"$CRESCA_REAL_GIT\" \"$@\" || exit $?\n  printf 'injected tracking publication failure\\n' >&2\n  exit 58\nfi\nexec \"$CRESCA_REAL_GIT\" \"$@\"\n",
+    );
+
+    let output = run_cresca_with_git_wrapper(&repo, &wrapper, &["review", "main", "develop"]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("injected tracking publication failure"),
+        "{stderr}"
+    );
+    assert_eq!(repo.snapshot(), before);
+    assert_eq!(repo.rev_parse("refs/remotes/origin/main"), before_target);
+    assert_eq!(repo.rev_parse("refs/remotes/origin/develop"), before_source);
+}
+
+#[test]
+fn test_isolated_fetch_does_not_auto_follow_tags_on_late_failure() {
+    let (repo, _) = setup_linear_range();
+    repo.switch_branch("develop");
+    repo.write_file("tagged-source.txt", "tagged source\n");
+    repo.git(&["add", "tagged-source.txt"]);
+    repo.commit("Add remotely tagged source");
+    repo.git(&["tag", "remote-review-tag"]);
+    repo.git(&["push", "origin", "develop", "refs/tags/remote-review-tag"]);
+    repo.git(&["tag", "-d", "remote-review-tag"]);
+    repo.switch_branch("main");
+    assert!(!repo.ref_exists("refs/tags/remote-review-tag"));
+    let wrapper = install_git_wrapper(
+        &repo,
+        "#!/bin/sh\ncase \" $* \" in\n  *' fetch '*)\n    case \" $* \" in\n      *' --no-tags '*) ;;\n      *) printf 'isolated fetch omitted --no-tags\\n' >&2; exit 59 ;;\n    esac\n    ;;\nesac\ncase \"$*\" in\n  *'config --local --replace-all branch.review-main-develop.cresca-scope'*)\n    \"$CRESCA_REAL_GIT\" \"$@\" || exit $?\n    printf 'late tagged review failure\\n' >&2\n    exit 60\n    ;;\nesac\nexec \"$CRESCA_REAL_GIT\" \"$@\"\n",
+    );
+
+    let output = run_cresca_with_git_wrapper(&repo, &wrapper, &["review", "main", "develop"]);
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("late tagged review failure"));
+    assert!(
+        !repo.ref_exists("refs/tags/remote-review-tag"),
+        "isolated fetch must not auto-follow a newly reachable remote tag"
+    );
+}
+
+#[test]
+fn test_fatal_remote_tracking_probe_is_rendered_without_mutation() {
+    let (repo, _) = setup_linear_range();
+    let before = repo.snapshot();
+    let wrapper = install_git_wrapper(
+        &repo,
+        "#!/bin/sh\nif [ \"$1\" = rev-parse ] && [ \"$2\" = --verify ] && [ \"$3\" = --quiet ]; then\n  printf 'fatal remote tracking probe\\n' >&2\n  exit 128\nfi\nexec \"$CRESCA_REAL_GIT\" \"$@\"\n",
+    );
+
+    let output = run_cresca_with_git_wrapper(&repo, &wrapper, &["review", "main", "develop"]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("verify if branch is already a remote tracking branch"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("exit status: 128"), "{stderr}");
+    assert!(stderr.contains("fatal remote tracking probe"), "{stderr}");
+    assert_eq!(repo.snapshot(), before);
+}
+
+#[test]
+fn test_fatal_upstream_probe_is_rendered_without_mutation() {
+    let (repo, _) = setup_linear_range();
+    repo.git(&["update-ref", "-d", "refs/remotes/origin/main"]);
+    repo.git(&["update-ref", "-d", "refs/remotes/origin/develop"]);
+    let before = repo.snapshot();
+    let wrapper = install_git_wrapper(
+        &repo,
+        "#!/bin/sh\nif [ \"$1\" = rev-parse ] && [ \"$2\" = --abbrev-ref ]; then\n  case \"$3\" in\n    *'@{upstream}') printf 'fatal upstream probe\\n' >&2; exit 128 ;;\n  esac\nfi\nif [ \"$1\" = for-each-ref ]; then\n  case \"$*\" in\n    *'%(upstream:short)'*) printf 'fatal upstream probe\\n' >&2; exit 128 ;;\n  esac\nfi\nexec \"$CRESCA_REAL_GIT\" \"$@\"\n",
+    );
+
+    let output = run_cresca_with_git_wrapper(&repo, &wrapper, &["review", "main", "develop"]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("get upstream branch"), "{stderr}");
+    assert!(stderr.contains("exit status: 128"), "{stderr}");
+    assert!(stderr.contains("fatal upstream probe"), "{stderr}");
+    assert_eq!(repo.snapshot(), before);
+}
+
+#[test]
+fn test_fatal_scope_object_probe_is_rendered_without_mutation() {
+    let repo = setup_identity_only_review_branch();
+    let scope = format!("1:{}", repo.rev_parse("HEAD"));
+    repo.git(&[
+        "config",
+        "--local",
+        "branch.review-main-develop.cresca-scope",
+        &scope,
+    ]);
+    let before = repo.snapshot();
+    let wrapper = install_git_wrapper(
+        &repo,
+        "#!/bin/sh\nif [ \"$1\" = rev-parse ] && [ \"$2\" = --verify ]; then\n  printf 'fatal scope object probe\\n' >&2\n  exit 128\nfi\nif [ \"$1\" = cat-file ]; then\n  case \"$2\" in\n    --batch-check*) printf 'fatal scope object probe\\n' >&2; exit 128 ;;\n  esac\nfi\nexec \"$CRESCA_REAL_GIT\" \"$@\"\n",
+    );
+
+    let output = run_cresca_with_git_wrapper(&repo, &wrapper, &["status"]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("validate review range endpoint"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("exit status: 128"), "{stderr}");
+    assert!(stderr.contains("fatal scope object probe"), "{stderr}");
+    assert_eq!(repo.snapshot(), before);
+}
+
+#[test]
+fn test_late_failure_restores_commit_editmsg_and_preserves_rerere_state() {
+    let (repo, range) = setup_linear_range();
+    repo.git(&["config", "rerere.enabled", "true"]);
+    let commit_editmsg = repo.git_path("COMMIT_EDITMSG");
+    let merge_rr = repo.git_path("MERGE_RR");
+    let rr_cache = repo.git_path("rr-cache");
+    std::fs::write(&commit_editmsg, b"original commit edit message\n")
+        .expect("COMMIT_EDITMSG fixture should be written");
+    std::fs::write(&merge_rr, b"original merge rr state\n")
+        .expect("MERGE_RR fixture should be written");
+    std::fs::create_dir_all(rr_cache.join("fixture"))
+        .expect("rerere fixture directory should be created");
+    std::fs::write(rr_cache.join("fixture/preimage"), b"original preimage\n")
+        .expect("rerere preimage should be written");
+    std::fs::write(rr_cache.join("fixture/postimage"), b"original postimage\n")
+        .expect("rerere postimage should be written");
+    let before_commit_editmsg = std::fs::read(&commit_editmsg).unwrap();
+    let before_merge_rr = std::fs::read(&merge_rr).unwrap();
+    let before_rr_cache = snapshot_tree(&rr_cache);
+    let wrapper = install_git_wrapper(
+        &repo,
+        "#!/bin/sh\ncase \" $* \" in\n  *' merge '*)\n    case \"$*\" in\n      '-c rerere.enabled=false merge '*) ;;\n      *) printf 'review merge inherited rerere\\n' >&2; exit 60 ;;\n    esac\n    ;;\nesac\ncase \"$*\" in\n  *'config --local --replace-all branch.review-main-develop.cresca-scope'*)\n    \"$CRESCA_REAL_GIT\" \"$@\" || exit $?\n    printf 'late rerere-state failure\\n' >&2\n    exit 61\n    ;;\nesac\nexec \"$CRESCA_REAL_GIT\" \"$@\"\n",
+    );
+
+    let output = run_cresca_with_git_wrapper(
+        &repo,
+        &wrapper,
+        &["review", "main", "develop", "--skip-to", &range.b[..8]],
+    );
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("late rerere-state failure"), "{stderr}");
+    assert_eq!(
+        std::fs::read(commit_editmsg).unwrap(),
+        before_commit_editmsg
+    );
+    assert_eq!(std::fs::read(merge_rr).unwrap(), before_merge_rr);
+    assert_eq!(snapshot_tree(&rr_cache), before_rr_cache);
+}
+
+#[test]
+fn test_unchanged_restrictive_ignored_entries_are_not_recreated_during_rollback() {
+    let (repo, _) = setup_linear_range();
+    add_ignored_paths(&repo, "restrictive/\n");
+    let directory = repo.path().join("restrictive");
+    std::fs::create_dir(&directory).expect("restrictive directory should be created");
+    repo.write_file("restrictive/readonly.txt", "unchanged readonly content\n");
+    std::os::unix::fs::symlink("readonly.txt", directory.join("readonly-link"))
+        .expect("restrictive symlink should be created");
+    std::fs::set_permissions(
+        directory.join("readonly.txt"),
+        std::fs::Permissions::from_mode(0o444),
+    )
+    .unwrap();
+    std::fs::set_permissions(&directory, std::fs::Permissions::from_mode(0o555)).unwrap();
+    let _mode_guard = RestoreDirectoryMode {
+        path: directory.clone(),
+    };
+    let before = repo.snapshot();
+    let wrapper = install_git_wrapper(
+        &repo,
+        "#!/bin/sh\ncase \"$*\" in\n  *'config --local --replace-all branch.review-main-develop.cresca-scope'*)\n    \"$CRESCA_REAL_GIT\" \"$@\" || exit $?\n    printf 'late restrictive no-op failure\\n' >&2\n    exit 62\n    ;;\nesac\nexec \"$CRESCA_REAL_GIT\" \"$@\"\n",
+    );
+
+    let output = run_cresca_with_git_wrapper(&repo, &wrapper, &["review", "main", "develop"]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("late restrictive no-op failure"),
+        "{stderr}"
+    );
+    assert!(
+        !stderr.contains("Rollback or verification also failed"),
+        "{stderr}"
+    );
+    assert_eq!(repo.snapshot(), before);
+}
+
+#[test]
+fn test_changed_entry_beneath_restrictive_directory_is_restored() {
+    let (repo, _) = setup_linear_range();
+    add_ignored_paths(&repo, "restrictive/\n");
+    let directory = repo.path().join("restrictive");
+    std::fs::create_dir(&directory).expect("restrictive directory should be created");
+    repo.write_file("restrictive/readonly.txt", "original readonly content\n");
+    std::os::unix::fs::symlink("readonly.txt", directory.join("readonly-link"))
+        .expect("restrictive symlink should be created");
+    std::fs::set_permissions(
+        directory.join("readonly.txt"),
+        std::fs::Permissions::from_mode(0o444),
+    )
+    .unwrap();
+    std::fs::set_permissions(&directory, std::fs::Permissions::from_mode(0o555)).unwrap();
+    let _mode_guard = RestoreDirectoryMode {
+        path: directory.clone(),
+    };
+    let before = repo.snapshot();
+    let wrapper = install_git_wrapper(
+        &repo,
+        "#!/bin/sh\ncase \"$*\" in\n  *'config --local --replace-all branch.review-main-develop.cresca-scope'*)\n    \"$CRESCA_REAL_GIT\" \"$@\" || exit $?\n    /bin/chmod 755 restrictive\n    /bin/chmod 644 restrictive/readonly.txt\n    printf 'changed content\\n' > restrictive/readonly.txt\n    /bin/rm -f restrictive/readonly-link\n    /bin/ln -s changed-target restrictive/readonly-link\n    /bin/chmod 555 restrictive\n    printf 'late restrictive mutation failure\\n' >&2\n    exit 63\n    ;;\nesac\nexec \"$CRESCA_REAL_GIT\" \"$@\"\n",
+    );
+
+    let output = run_cresca_with_git_wrapper(&repo, &wrapper, &["review", "main", "develop"]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("late restrictive mutation failure"),
+        "{stderr}"
+    );
+    assert_eq!(repo.snapshot(), before);
+}
+
+#[test]
+fn test_review_preserves_custom_tmpdir_for_git_helpers() {
+    let (repo, _) = setup_linear_range();
+    let custom_tmpdir = tempfile::TempDir::new().expect("custom TMPDIR should be created");
+    let wrapper = install_git_wrapper(
+        &repo,
+        "#!/bin/sh\nif [ \"$TMPDIR\" != \"$CRESCA_EXPECTED_TMPDIR\" ]; then\n  printf 'TMPDIR changed: %s\\n' \"$TMPDIR\" >&2\n  exit 64\nfi\nexec \"$CRESCA_REAL_GIT\" \"$@\"\n",
+    );
+
+    let output = std::process::Command::new(TempGitRepo::cresca_binary())
+        .args(["review", "main", "develop"])
+        .env("NO_COLOR", "1")
+        .env("PATH", wrapper.path())
+        .env("CRESCA_REAL_GIT", real_git_path())
+        .env("TMPDIR", custom_tmpdir.path())
+        .env("CRESCA_EXPECTED_TMPDIR", custom_tmpdir.path())
+        .current_dir(repo.path())
+        .output()
+        .expect("Failed to execute cresca");
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 #[test]
@@ -527,7 +895,11 @@ fn test_failed_rereview_restores_previous_review_and_status_remains_usable() {
 #[test]
 fn test_review_failure_cleans_transaction_scratch_directory() {
     let (repo, _) = setup_linear_range();
-    let scratch_parent = tempfile::TempDir::new().expect("scratch parent should be created");
+    let scratch_parent = repo
+        .git_path("config")
+        .parent()
+        .expect("Git config should have a private parent")
+        .to_path_buf();
     let wrapper = install_git_wrapper(
         &repo,
         "#!/bin/sh\nif [ \"$1\" = checkout ] && [ \"$2\" = -b ]; then\n  \"$CRESCA_REAL_GIT\" \"$@\" || exit $?\n  printf 'injected scratch cleanup failure\\n' >&2\n  exit 51\nfi\nexec \"$CRESCA_REAL_GIT\" \"$@\"\n",
@@ -538,13 +910,12 @@ fn test_review_failure_cleans_transaction_scratch_directory() {
         .env("NO_COLOR", "1")
         .env("PATH", wrapper.path())
         .env("CRESCA_REAL_GIT", real_git_path())
-        .env("TMPDIR", scratch_parent.path())
         .current_dir(repo.path())
         .output()
         .expect("Failed to execute cresca");
 
     assert!(!output.status.success());
-    let cresca_scratch: Vec<_> = std::fs::read_dir(scratch_parent.path())
+    let cresca_scratch: Vec<_> = std::fs::read_dir(&scratch_parent)
         .expect("scratch parent should remain readable")
         .map(|entry| entry.expect("scratch entry should be readable").file_name())
         .filter(|name| name.to_string_lossy().starts_with("cresca-review-"))

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,6 +3,7 @@ mod common;
 use common::TempGitRepo;
 use std::collections::BTreeSet;
 use std::os::unix::fs::{FileTypeExt, PermissionsExt};
+use std::path::Path;
 
 fn install_git_wrapper(repo: &TempGitRepo, script: &str) -> tempfile::TempDir {
     let wrapper_dir = tempfile::TempDir::new().expect("wrapper directory should be created");
@@ -42,6 +43,272 @@ fn run_cresca_with_git_wrapper(
         .current_dir(repo.path())
         .output()
         .expect("Failed to execute cresca")
+}
+
+fn run_cresca_with_git_wrapper_from(
+    _repo: &TempGitRepo,
+    wrapper: &tempfile::TempDir,
+    current_dir: &Path,
+    args: &[&str],
+) -> std::process::Output {
+    std::process::Command::new(TempGitRepo::cresca_binary())
+        .args(args)
+        .env("NO_COLOR", "1")
+        .env("PATH", wrapper.path())
+        .env("CRESCA_REAL_GIT", real_git_path())
+        .current_dir(current_dir)
+        .output()
+        .unwrap_or_else(|error| {
+            panic!(
+                "Failed to execute cresca in {}: {error}",
+                current_dir.display()
+            )
+        })
+}
+
+fn add_ignored_paths(repo: &TempGitRepo, patterns: &str) {
+    repo.write_file(".gitignore", patterns);
+    repo.git(&["add", ".gitignore"]);
+    repo.commit("Add ignored rollback fixtures");
+    repo.git(&["push", "origin", "main"]);
+}
+
+#[test]
+fn test_dirty_review_rejects_before_scanning_ignored_fifo() {
+    let (repo, _) = setup_linear_range();
+    add_ignored_paths(&repo, "ignored.pipe\n");
+    let fifo_path = repo.path().join("ignored.pipe");
+    let mkfifo = std::process::Command::new("mkfifo")
+        .arg(&fifo_path)
+        .output()
+        .expect("mkfifo should be executable");
+    assert!(mkfifo.status.success());
+    repo.write_file("README.md", "dirty tracked content\n");
+    let before = repo.snapshot();
+
+    let output = repo.run_cresca(&["review", "main", "develop"]);
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("Uncommitted changes found"),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(repo.snapshot(), before);
+    assert!(std::fs::symlink_metadata(fifo_path)
+        .expect("ignored FIFO should survive dirty rejection")
+        .file_type()
+        .is_fifo());
+}
+
+#[test]
+fn test_tmpdir_inside_worktree_does_not_endanger_transaction_backup() {
+    let (repo, _) = setup_linear_range();
+    add_ignored_paths(&repo, ".scratch/\n");
+    let scratch_parent = repo.path().join(".scratch");
+    std::fs::create_dir(&scratch_parent).expect("in-worktree TMPDIR should be created");
+    let before = repo.snapshot();
+    let wrapper = install_git_wrapper(
+        &repo,
+        "#!/bin/sh\nif [ \"$1\" = reset ]; then\n  \"$CRESCA_REAL_GIT\" \"$@\" || exit $?\n  printf 'late failure with in-worktree TMPDIR\\n' >&2\n  exit 54\nfi\nexec \"$CRESCA_REAL_GIT\" \"$@\"\n",
+    );
+
+    let output = std::process::Command::new(TempGitRepo::cresca_binary())
+        .args(["review", "main", "develop"])
+        .env("NO_COLOR", "1")
+        .env("PATH", wrapper.path())
+        .env("CRESCA_REAL_GIT", real_git_path())
+        .env("TMPDIR", &scratch_parent)
+        .current_dir(repo.path())
+        .output()
+        .expect("Failed to execute cresca");
+
+    assert!(!output.status.success());
+    assert_eq!(repo.snapshot(), before);
+    assert!(
+        std::fs::read_dir(&scratch_parent)
+            .expect("in-worktree TMPDIR should remain")
+            .next()
+            .is_none(),
+        "transaction scratch must be cleaned without deleting its parent"
+    );
+}
+
+#[test]
+fn test_fatal_show_ref_probe_is_rendered_without_mutation() {
+    let (repo, _) = setup_linear_range();
+    let before = repo.snapshot();
+    let wrapper = install_git_wrapper(
+        &repo,
+        "#!/bin/sh\nif [ \"$1\" = show-ref ]; then\n  printf 'fatal show-ref failure\\n' >&2\n  exit 128\nfi\nexec \"$CRESCA_REAL_GIT\" \"$@\"\n",
+    );
+
+    let output = run_cresca_with_git_wrapper(&repo, &wrapper, &["review", "main", "develop"]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("check existence of review branch"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("exit status: 128"), "{stderr}");
+    assert!(stderr.contains("fatal show-ref failure"), "{stderr}");
+    assert_eq!(repo.snapshot(), before);
+    assert!(!repo.ref_exists("refs/heads/review-main-develop"));
+}
+
+#[test]
+fn test_fatal_skip_to_rev_list_is_rendered_without_mutation() {
+    let (repo, range) = setup_linear_range();
+    let before = repo.snapshot();
+    let wrapper = install_git_wrapper(
+        &repo,
+        "#!/bin/sh\nif [ \"$1\" = rev-list ]; then\n  count_file=\"$0.rev-list-count\"\n  count=0\n  if [ -f \"$count_file\" ]; then IFS= read -r count < \"$count_file\"; fi\n  count=$((count + 1))\n  printf '%s\\n' \"$count\" > \"$count_file\"\n  if [ \"$count\" -eq 2 ]; then\n    printf 'fatal skip-to rev-list failure\\n' >&2\n    exit 128\n  fi\nfi\nexec \"$CRESCA_REAL_GIT\" \"$@\"\n",
+    );
+
+    let output = run_cresca_with_git_wrapper(
+        &repo,
+        &wrapper,
+        &["review", "main", "develop", "--skip-to", &range.b[..8]],
+    );
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("check earlier commits"), "{stderr}");
+    assert!(stderr.contains("exit status: 128"), "{stderr}");
+    assert!(
+        stderr.contains("fatal skip-to rev-list failure"),
+        "{stderr}"
+    );
+    assert_eq!(repo.snapshot(), before);
+    assert!(!repo.ref_exists("refs/heads/review-main-develop"));
+}
+
+#[test]
+fn test_nested_invocation_late_failure_rolls_back_without_losing_cwd() {
+    let (repo, _) = setup_linear_range();
+    add_ignored_paths(&repo, "nested/\n");
+    let nested = repo.path().join("nested/deeper");
+    std::fs::create_dir_all(&nested).expect("nested invocation directory should be created");
+    repo.write_file("nested/deeper/ignored.txt", "nested original\n");
+    let before = repo.snapshot();
+    let wrapper = install_git_wrapper(
+        &repo,
+        "#!/bin/sh\ncase \"$*\" in\n  *'config --local --replace-all branch.review-main-develop.cresca-scope'*)\n    \"$CRESCA_REAL_GIT\" \"$@\" || exit $?\n    printf 'nested late failure\\n' >&2\n    exit 55\n    ;;\nesac\nexec \"$CRESCA_REAL_GIT\" \"$@\"\n",
+    );
+
+    let output =
+        run_cresca_with_git_wrapper_from(&repo, &wrapper, &nested, &["review", "main", "develop"]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("nested late failure"), "{stderr}");
+    assert!(!stderr.contains("getcwd"), "{stderr}");
+    assert_eq!(repo.snapshot(), before);
+    assert_eq!(
+        repo.read_file("nested/deeper/ignored.txt"),
+        "nested original\n"
+    );
+}
+
+#[test]
+fn test_repository_snapshot_detects_ignored_content_mode_and_symlink_changes() {
+    let repo = TempGitRepo::new();
+    add_ignored_paths(&repo, "ignored.txt\nignored-link\n");
+    repo.write_file("ignored.txt", "ignored original\n");
+    std::fs::set_permissions(
+        repo.path().join("ignored.txt"),
+        std::fs::Permissions::from_mode(0o600),
+    )
+    .expect("ignored file mode should be set");
+    std::os::unix::fs::symlink("target-a", repo.path().join("ignored-link"))
+        .expect("ignored symlink should be created");
+    let before = repo.snapshot();
+
+    repo.write_file("ignored.txt", "ignored changed\n");
+    std::fs::set_permissions(
+        repo.path().join("ignored.txt"),
+        std::fs::Permissions::from_mode(0o755),
+    )
+    .expect("ignored file mode should change");
+    std::fs::remove_file(repo.path().join("ignored-link"))
+        .expect("ignored symlink should be removable");
+    std::os::unix::fs::symlink("target-b", repo.path().join("ignored-link"))
+        .expect("ignored symlink target should change");
+    let after = repo.snapshot();
+
+    assert_ne!(after, before, "snapshot must include ignored entry state");
+}
+
+#[test]
+fn test_late_failure_restores_remote_refs_and_git_admin_files() {
+    let (repo, _) = setup_linear_range();
+    let stale_tracking = repo.rev_parse("refs/remotes/origin/develop");
+    repo.switch_branch("develop");
+    repo.write_file("remote-new.txt", "new remote content\n");
+    repo.git(&["add", "remote-new.txt"]);
+    repo.commit("Advance remote develop");
+    repo.git(&["push", "origin", "develop"]);
+    repo.git(&["update-ref", "refs/remotes/origin/develop", &stale_tracking]);
+    repo.switch_branch("main");
+    let admin_fixtures = [
+        ("FETCH_HEAD", b"original fetch head\n".as_slice()),
+        ("ORIG_HEAD", b"original orig head\n".as_slice()),
+        ("SQUASH_MSG", b"original squash message\n".as_slice()),
+    ];
+    for &(name, content) in &admin_fixtures {
+        std::fs::write(repo.git_path(name), content).expect("admin fixture should be written");
+    }
+    let before = repo.snapshot();
+    let before_remote = repo.rev_parse("refs/remotes/origin/develop");
+    let before_admin: Vec<_> = admin_fixtures
+        .iter()
+        .map(|(name, _)| (*name, std::fs::read(repo.git_path(name)).unwrap()))
+        .collect();
+    let wrapper = install_git_wrapper(
+        &repo,
+        "#!/bin/sh\ncase \"$*\" in\n  *'config --local --replace-all branch.review-main-develop.cresca-scope'*)\n    \"$CRESCA_REAL_GIT\" \"$@\" || exit $?\n    printf 'late admin-state failure\\n' >&2\n    exit 56\n    ;;\nesac\nexec \"$CRESCA_REAL_GIT\" \"$@\"\n",
+    );
+
+    let output = run_cresca_with_git_wrapper(&repo, &wrapper, &["review", "main", "develop"]);
+
+    assert!(!output.status.success());
+    assert_eq!(repo.snapshot(), before);
+    assert_eq!(repo.rev_parse("refs/remotes/origin/develop"), before_remote);
+    for (name, expected) in before_admin {
+        assert_eq!(
+            std::fs::read(repo.git_path(name)).unwrap(),
+            expected,
+            "{name}"
+        );
+    }
+}
+
+#[test]
+fn test_partial_reconcile_failure_still_restores_independent_paths() {
+    let (repo, _) = setup_linear_range();
+    add_ignored_paths(&repo, "a-restore.txt\nzz-blocked/\n");
+    repo.write_file("a-restore.txt", "must be restored\n");
+    repo.write_file("zz-blocked/child.txt", "blocked original\n");
+    let wrapper = install_git_wrapper(
+        &repo,
+        "#!/bin/sh\ncase \"$*\" in\n  *'config --local --replace-all branch.review-main-develop.cresca-scope'*)\n    \"$CRESCA_REAL_GIT\" \"$@\" || exit $?\n    /bin/rm -f a-restore.txt\n    /bin/chmod 000 zz-blocked\n    printf 'original injected failure\\n' >&2\n    exit 57\n    ;;\nesac\nexec \"$CRESCA_REAL_GIT\" \"$@\"\n",
+    );
+
+    let output = run_cresca_with_git_wrapper(&repo, &wrapper, &["review", "main", "develop"]);
+    let blocked = repo.path().join("zz-blocked");
+    if blocked.exists() {
+        let _ = std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o700));
+    }
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("original injected failure"), "{stderr}");
+    assert!(
+        stderr.contains("Rollback or verification also failed"),
+        "{stderr}"
+    );
+    assert_eq!(repo.read_file("a-restore.txt"), "must be restored\n");
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -652,6 +652,89 @@ fn test_changed_entry_beneath_restrictive_directory_is_restored() {
 }
 
 #[test]
+fn test_failed_backup_copy_restores_widened_file_mode_and_continues() {
+    let (repo, _) = setup_linear_range();
+    add_ignored_paths(&repo, "copy-failure/\n");
+    let directory = repo.path().join("copy-failure");
+    std::fs::create_dir(&directory).expect("copy-failure directory should be created");
+    repo.write_file("copy-failure/readonly.txt", "original readonly content\n");
+    repo.write_file(
+        "copy-failure/zz-independent.txt",
+        "independent original content\n",
+    );
+    std::fs::set_permissions(
+        directory.join("readonly.txt"),
+        std::fs::Permissions::from_mode(0o444),
+    )
+    .unwrap();
+    std::fs::set_permissions(&directory, std::fs::Permissions::from_mode(0o555)).unwrap();
+    let _mode_guard = RestoreDirectoryMode {
+        path: directory.clone(),
+    };
+    let wrapper = install_git_wrapper(
+        &repo,
+        "#!/bin/sh\ncase \"$*\" in\n  *'config --local --replace-all branch.review-main-develop.cresca-scope'*)\n    \"$CRESCA_REAL_GIT\" \"$@\" || exit $?\n    /bin/chmod 755 copy-failure\n    /bin/chmod 644 copy-failure/readonly.txt\n    printf 'changed readonly content\\n' > copy-failure/readonly.txt\n    /bin/chmod 444 copy-failure/readonly.txt\n    /bin/rm -f copy-failure/zz-independent.txt\n    /bin/chmod 555 copy-failure\n    for backup in .git/cresca-review-*/worktree/copy-failure/readonly.txt; do\n      if [ -f \"$backup\" ]; then /bin/rm -f \"$backup\"; fi\n    done\n    printf 'late backup-copy failure\\n' >&2\n    exit 65\n    ;;\nesac\nexec \"$CRESCA_REAL_GIT\" \"$@\"\n",
+    );
+
+    let output = run_cresca_with_git_wrapper(&repo, &wrapper, &["review", "main", "develop"]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("late backup-copy failure"), "{stderr}");
+    assert!(
+        stderr.contains("restore file `copy-failure/readonly.txt`"),
+        "{stderr}"
+    );
+    assert_eq!(
+        std::fs::symlink_metadata(directory.join("readonly.txt"))
+            .unwrap()
+            .mode()
+            & 0o777,
+        0o444,
+        "a failed backup copy must not leave the user's file writable"
+    );
+    assert_eq!(
+        repo.read_file("copy-failure/zz-independent.txt"),
+        "independent original content\n",
+        "a failed path must not skip later independent restoration"
+    );
+}
+
+#[test]
+fn test_generated_nested_mode_zero_directory_is_removed_on_rollback() {
+    let (repo, _) = setup_linear_range();
+    let before = repo.snapshot();
+    let generated = repo.path().join("generated-locked");
+    let nested = generated.join("nested");
+    let _nested_guard = RestoreDirectoryMode {
+        path: nested.clone(),
+    };
+    let _generated_guard = RestoreDirectoryMode {
+        path: generated.clone(),
+    };
+    let wrapper = install_git_wrapper(
+        &repo,
+        "#!/bin/sh\ncase \"$*\" in\n  *'config --local --replace-all branch.review-main-develop.cresca-scope'*)\n    \"$CRESCA_REAL_GIT\" \"$@\" || exit $?\n    /bin/mkdir -p generated-locked/nested\n    printf 'generated locked content\\n' > generated-locked/nested/file.txt\n    /bin/chmod 000 generated-locked/nested\n    /bin/chmod 000 generated-locked\n    printf 'late generated-directory failure\\n' >&2\n    exit 66\n    ;;\nesac\nexec \"$CRESCA_REAL_GIT\" \"$@\"\n",
+    );
+
+    let output = run_cresca_with_git_wrapper(&repo, &wrapper, &["review", "main", "develop"]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("late generated-directory failure"),
+        "{stderr}"
+    );
+    let survived = generated.exists();
+    if survived {
+        let _ = std::fs::set_permissions(&generated, std::fs::Permissions::from_mode(0o755));
+        let _ = std::fs::set_permissions(&nested, std::fs::Permissions::from_mode(0o755));
+    }
+    assert!(!survived, "generated mode-000 directory survived rollback");
+    assert_eq!(repo.snapshot(), before);
+}
+
+#[test]
 fn test_review_preserves_custom_tmpdir_for_git_helpers() {
     let (repo, _) = setup_linear_range();
     let custom_tmpdir = tempfile::TempDir::new().expect("custom TMPDIR should be created");


### PR DESCRIPTION
Review preparation now propagates Git failures instead of terminating inside helpers and rolls ordinary failures back to the exact pre-review branch, refs, config, index, worktree, and generated-path state. Git errors retain and display the command, exit status, stdout, and stderr, while the existing CLI arguments, metadata version 1, scope version 1, and range-aware status behavior remain unchanged.

Snapshots are disk-backed in Git-private scratch storage, and remote computation stays isolated until successful tracking-ref publication. Unsupported filesystem entries fail before mutation. Durable recovery after SIGKILL or power loss remains out of scope.
