### PR TITLE
fix(review): reconstruct approvals from explicit bases

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,6 @@ Use `git log --oneline main..develop` to see available commits.
 cresca status
 ```
 
-Use `--all` to include unapproved changes after that range and show the remaining diff across the full pull request:
-
-```sh
-cresca status --all
-```
-
 ## License
 
 [MIT](https://github.com/Lfu001/cresca/blob/main/LICENSE)

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -498,11 +498,11 @@ pub fn get_full_review_status(
     let target_oid = resolve("resolve current review target", &target.tracking_ref)?;
     let source_oid = resolve("resolve current review source", &source.tracking_ref)?;
     let review_head = resolve("resolve current review head", "HEAD")?;
-    let old_base = match explicit_review_base(&review_head, verbose)? {
+    let new_base = unique_merge_base(&target_oid, &source_oid, verbose)?;
+    let old_base = match explicit_review_base(&review_head, &new_base, verbose)? {
         Some(base) => base,
         None => unique_merge_base(&review_head, &source_oid, verbose)?,
     };
-    let new_base = unique_merge_base(&target_oid, &source_oid, verbose)?;
 
     let object_path = run_git_command(
         "locate Git object database",

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -499,7 +499,7 @@ pub fn get_full_review_status(
     let source_oid = resolve("resolve current review source", &source.tracking_ref)?;
     let review_head = resolve("resolve current review head", "HEAD")?;
     let new_base = unique_merge_base(&target_oid, &source_oid, verbose)?;
-    let old_base = match explicit_review_base(&review_head, &new_base, verbose)? {
+    let old_base = match explicit_review_base(&review_head, &target_oid, verbose)? {
         Some(base) => base,
         None => unique_merge_base(&review_head, &source_oid, verbose)?,
     };

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -4,12 +4,10 @@ use crate::git::{
     ReviewBranchSelectionError, ReviewMetadata, ReviewScope, ReviewScopeError,
 };
 use crate::review::{
-    explicit_review_base, reconstruct_approval_tree, reconstruct_approval_tree_with_env,
-    review_commit_message, unique_merge_base, ReviewError, ReviewPreparation, ReviewTransaction,
+    reconstruct_approval_tree, review_commit_message, unique_merge_base, ReviewError,
+    ReviewPreparation, ReviewTransaction,
 };
-use std::ffi::OsStr;
 use std::ops::Not;
-use std::{fs, path::PathBuf};
 
 struct ReviewPlan {
     metadata: ReviewMetadata,
@@ -480,74 +478,6 @@ pub struct ReviewStatus {
     pub files: Vec<String>,
 }
 
-pub fn get_full_review_status(
-    metadata: &ReviewMetadata,
-    verbose: bool,
-) -> Result<ReviewStatus, ReviewError> {
-    let target = resolve_remote_tracking_branch(&metadata.target, verbose)?;
-    let source = resolve_remote_tracking_branch(&metadata.source, verbose)?;
-    let resolve = |description: &str, revision: &str| -> Result<String, ReviewError> {
-        let output = run_git_command(
-            description,
-            &["rev-parse", "--verify", &format!("{revision}^{{commit}}")],
-            &[],
-            verbose,
-        )?;
-        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
-    };
-    let target_oid = resolve("resolve current review target", &target.tracking_ref)?;
-    let source_oid = resolve("resolve current review source", &source.tracking_ref)?;
-    let review_head = resolve("resolve current review head", "HEAD")?;
-    let new_base = unique_merge_base(&target_oid, &source_oid, verbose)?;
-    let old_base = match explicit_review_base(&review_head, &target_oid, verbose)? {
-        Some(base) => base,
-        None => unique_merge_base(&review_head, &source_oid, verbose)?,
-    };
-
-    let object_path = run_git_command(
-        "locate Git object database",
-        &["rev-parse", "--git-path", "objects"],
-        &[],
-        verbose,
-    )?;
-    let object_path = PathBuf::from(String::from_utf8_lossy(&object_path.stdout).trim());
-    let object_path = if object_path.is_absolute() {
-        object_path
-    } else {
-        ReviewTransaction::repository_root(verbose)?.join(object_path)
-    };
-    let scratch = tempfile::TempDir::new().map_err(|error| {
-        ReviewError::Message(format!(
-            "failed to create temporary status reconstruction area: {error}"
-        ))
-    })?;
-    let scratch_objects = scratch.path().join("objects");
-    fs::create_dir(&scratch_objects).map_err(|error| {
-        ReviewError::Message(format!(
-            "failed to initialize temporary status object database: {error}"
-        ))
-    })?;
-    let env = [
-        ("GIT_OBJECT_DIRECTORY", scratch_objects.as_os_str()),
-        ("GIT_ALTERNATE_OBJECT_DIRECTORIES", object_path.as_os_str()),
-    ];
-    let reconstructed = reconstruct_approval_tree_with_env(
-        &old_base,
-        &new_base,
-        &review_head,
-        verbose,
-        Some(&env),
-    )?;
-    get_review_status_between(
-        &reconstructed.tree_oid,
-        &source_oid,
-        &format!("to {}", metadata.source),
-        verbose,
-        Some(&env),
-    )
-    .map_err(ReviewError::Git)
-}
-
 /// Get review status (remaining diff stats)
 ///
 /// # Arguments
@@ -564,34 +494,21 @@ pub fn get_review_status(
     display_label: &str,
     verbose: bool,
 ) -> Result<ReviewStatus, crate::git::GitCommandError> {
-    get_review_status_between("HEAD", compare_ref, display_label, verbose, None)
+    calculate_review_status_between("HEAD", compare_ref, display_label, verbose)
 }
 
-fn status_git(
-    description: &str,
-    args: &[&str],
-    verbose: bool,
-    env: Option<&[(&str, &OsStr)]>,
-) -> Result<std::process::Output, crate::git::GitCommandError> {
-    match env {
-        Some(env) => crate::git::run_git_command_with_env(description, args, env, &[], verbose),
-        None => run_git_command(description, args, &[], verbose),
-    }
-}
-
-fn get_review_status_between(
+fn calculate_review_status_between(
     review_ref: &str,
     compare_ref: &str,
     display_label: &str,
     verbose: bool,
-    env: Option<&[(&str, &OsStr)]>,
 ) -> Result<ReviewStatus, crate::git::GitCommandError> {
     // Get diff stats summary (use HEAD..branch for direct comparison, not HEAD...branch)
-    let stat_output = status_git(
+    let stat_output = run_git_command(
         "get diff stats",
         &["diff", "--stat", review_ref, compare_ref],
+        &[],
         verbose,
-        env,
     )?;
     let stat_str = String::from_utf8_lossy(&stat_output.stdout);
 
@@ -620,11 +537,11 @@ fn get_review_status_between(
     }
 
     // Get list of changed files
-    let files_output = status_git(
+    let files_output = run_git_command(
         "get changed files",
         &["diff", "--name-only", review_ref, compare_ref],
+        &[],
         verbose,
-        env,
     )?;
     let files: Vec<String> = String::from_utf8_lossy(&files_output.stdout)
         .lines()

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,16 +1,23 @@
 use crate::git::{
-    is_clean, resolve_remote_tracking_branch, run_git_command, select_review_branch,
-    write_review_metadata, write_review_scope, ReviewBranchSelection, ReviewBranchSelectionError,
-    ReviewMetadata, ReviewScope,
+    is_clean, read_review_scope, resolve_remote_tracking_branch, run_git_command,
+    select_review_branch, write_review_metadata, write_review_scope, ReviewBranchSelection,
+    ReviewBranchSelectionError, ReviewMetadata, ReviewScope, ReviewScopeError,
 };
-use crate::review::{ReviewError, ReviewTransaction};
+use crate::review::{
+    reconstruct_approval_tree, reconstruct_approval_tree_with_env, unique_merge_base, ReviewError,
+    ReviewPreparation, ReviewTransaction,
+};
+use std::ffi::OsStr;
 use std::ops::Not;
+use std::{fs, path::PathBuf};
 
 struct ReviewPlan {
     metadata: ReviewMetadata,
-    merge_base: String,
+    new_base: String,
     auto_approve_parent: Option<String>,
     selection: ReviewBranchSelection,
+    old_review: Option<String>,
+    old_base: Option<String>,
     scope: ReviewScope,
     tracking_updates: Vec<(String, String)>,
 }
@@ -30,7 +37,7 @@ pub fn prepare_review_branch(
     skip_to: Option<&str>,
     stop_at: Option<&str>,
     verbose: bool,
-) -> Result<bool, ReviewError> {
+) -> Result<ReviewPreparation, ReviewError> {
     let root = ReviewTransaction::repository_root(verbose)?;
     std::env::set_current_dir(&root).map_err(|error| {
         ReviewError::Message(format!(
@@ -64,34 +71,40 @@ fn prepare_review_plan(
     let resolved_to = resolve_remote_tracking_branch(to_branch, verbose)?;
     let resolved_from = resolve_remote_tracking_branch(from_branch, verbose)?;
 
-    let tracking_to = fetch_remote_commit(
-        "target",
-        &resolved_to.remote,
-        &resolved_to.remote_branch,
-        verbose,
-    )?;
     let tracking_from = fetch_remote_commit(
         "source",
         &resolved_from.remote,
         &resolved_from.remote_branch,
         verbose,
     )?;
-
-    // Get merge-base
-    let merge_base_output = run_git_command(
-        "get merge base",
-        &["merge-base", &tracking_to, &tracking_from],
-        &[],
+    let scope_end_revision = stop_at.unwrap_or(&tracking_from);
+    let scope_end_commit = format!("{scope_end_revision}^{{commit}}");
+    let scope_end_output = run_git_command(
+        "resolve review range endpoint",
+        &["rev-parse", "--verify", &scope_end_commit],
+        &[128],
         verbose,
     )?;
-    let merge_base = String::from_utf8_lossy(&merge_base_output.stdout)
+    if !scope_end_output.status.success() {
+        return Err(ReviewError::Message(format!(
+            "Commit {} is not in the range {}..{}",
+            scope_end_revision, to_branch, from_branch
+        )));
+    }
+    let endpoint = String::from_utf8_lossy(&scope_end_output.stdout)
         .trim()
         .to_string();
+    let tracking_to = fetch_remote_commit(
+        "target",
+        &resolved_to.remote,
+        &resolved_to.remote_branch,
+        verbose,
+    )?;
+    let new_base = unique_merge_base(&tracking_to, &endpoint, verbose)?;
 
-    // Get valid commit range (merge_base..tracking_from)
     let valid_commits = run_git_command(
         "get valid commit range",
-        &["rev-list", &format!("{}..{}", merge_base, tracking_from)],
+        &["rev-list", &format!("{}..{}", new_base, tracking_from)],
         &[],
         verbose,
     )?;
@@ -148,25 +161,16 @@ fn prepare_review_plan(
         }
     }
 
-    let scope_end_revision = stop_at.unwrap_or(&tracking_from);
-    let scope_end_commit = format!("{scope_end_revision}^{{commit}}");
-    let scope_end_output = run_git_command(
-        "resolve review range endpoint",
-        &["rev-parse", "--verify", &scope_end_commit],
-        &[],
-        verbose,
-    )?;
     let scope = ReviewScope {
-        end_oid: String::from_utf8_lossy(&scope_end_output.stdout)
-            .trim()
-            .to_string(),
+        base_oid: Some(new_base.clone()),
+        end_oid: endpoint,
     };
 
     let auto_approve_parent = if let Some(hash) = skip_to {
         let parent = format!("{}^", hash);
         let has_earlier = run_git_command(
             "check earlier commits",
-            &["rev-list", &format!("{}..{}", merge_base, parent)],
+            &["rev-list", &format!("{}..{}", new_base, parent)],
             &[],
             verbose,
         )?;
@@ -179,6 +183,42 @@ fn prepare_review_plan(
         ReviewBranchSelectionError::Git(error) => ReviewError::Git(error),
         ReviewBranchSelectionError::Conflict(message) => ReviewError::Message(message),
     })?;
+    let (old_review, old_base) = match &selection {
+        ReviewBranchSelection::New(_) => (None, None),
+        ReviewBranchSelection::Existing(branch) => {
+            let old_review = String::from_utf8_lossy(
+                &run_git_command(
+                    "resolve previous review head",
+                    &[
+                        "rev-parse",
+                        "--verify",
+                        &format!("refs/heads/{branch}^{{commit}}"),
+                    ],
+                    &[],
+                    verbose,
+                )?
+                .stdout,
+            )
+            .trim()
+            .to_string();
+            let old_base = match read_review_scope(branch, verbose) {
+                Ok(saved) => match saved.base_oid {
+                    Some(base) => base,
+                    None => unique_merge_base(&old_review, &saved.end_oid, verbose)?,
+                },
+                Err(ReviewScopeError::Missing) => {
+                    unique_merge_base(&old_review, &tracking_from, verbose)?
+                }
+                Err(ReviewScopeError::Git(error)) => return Err(error.into()),
+                Err(error) => {
+                    return Err(ReviewError::Message(format!(
+                        "Cannot safely migrate existing review range metadata: {error:?}"
+                    )))
+                }
+            };
+            (Some(old_review), Some(old_base))
+        }
+    };
     let tracking_updates = vec![
         (
             format!("refs/remotes/{}", resolved_to.tracking_ref),
@@ -192,9 +232,11 @@ fn prepare_review_plan(
 
     Ok(ReviewPlan {
         metadata,
-        merge_base,
+        new_base,
         auto_approve_parent,
         selection,
+        old_review,
+        old_base,
         scope,
         tracking_updates,
     })
@@ -247,12 +289,54 @@ fn fetch_remote_commit(
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
-fn apply_review_plan(plan: ReviewPlan, verbose: bool) -> Result<bool, ReviewError> {
+fn merge_auto_approved_tree(
+    base: &str,
+    approved_tree: &str,
+    auto_approve_parent: &str,
+    verbose: bool,
+) -> Result<String, ReviewError> {
+    let output = run_git_command(
+        "compose explicitly auto-approved tree",
+        &[
+            "merge-tree",
+            "--write-tree",
+            &format!("--merge-base={base}"),
+            "-Xtheirs",
+            "-Xfind-renames=100%",
+            "--no-messages",
+            approved_tree,
+            auto_approve_parent,
+        ],
+        &[],
+        verbose,
+    )?;
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn commit_tree(
+    description: &str,
+    tree: &str,
+    parent: &str,
+    message: &str,
+    verbose: bool,
+) -> Result<String, ReviewError> {
+    let output = run_git_command(
+        description,
+        &["commit-tree", tree, "-p", parent, "-m", message],
+        &[],
+        verbose,
+    )?;
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn apply_review_plan(plan: ReviewPlan, verbose: bool) -> Result<ReviewPreparation, ReviewError> {
     let ReviewPlan {
         metadata,
-        merge_base,
+        new_base,
         auto_approve_parent,
         selection,
+        old_review,
+        old_base,
         scope,
         tracking_updates,
     } = plan;
@@ -273,7 +357,7 @@ fn apply_review_plan(plan: ReviewPlan, verbose: bool) -> Result<bool, ReviewErro
         ReviewBranchSelection::New(name) => {
             run_git_command(
                 "create review branch from merge-base",
-                &["checkout", "-b", &name, &merge_base],
+                &["checkout", "-b", &name, &new_base],
                 &[],
                 verbose,
             )?;
@@ -281,61 +365,71 @@ fn apply_review_plan(plan: ReviewPlan, verbose: bool) -> Result<bool, ReviewErro
         }
     };
 
-    if let Some(parent) = auto_approve_parent {
-        // Auto-approve commits before skip_to by squash merging them
+    let (mut approved_tree, parent) = if is_new {
+        (format!("{new_base}^{{tree}}"), new_base.clone())
+    } else {
+        let old_review = old_review
+            .as_deref()
+            .expect("existing review must have a head");
+        let old_base = old_base
+            .as_deref()
+            .expect("existing review must have a base");
+        (
+            reconstruct_approval_tree(old_base, &new_base, old_review, verbose)?.tree_oid,
+            old_review.to_string(),
+        )
+    };
+    if let Some(auto_parent) = auto_approve_parent.as_deref() {
+        approved_tree = merge_auto_approved_tree(&new_base, &approved_tree, auto_parent, verbose)?;
+    }
+
+    let new_review = if !is_new || auto_approve_parent.is_some() {
+        let message = if is_new {
+            "Auto-approve earlier commits"
+        } else {
+            "Reconstruct approved changes"
+        };
+        let description = if is_new {
+            "commit auto-approved changes"
+        } else {
+            "commit reconstructed approved tree"
+        };
+        let commit = commit_tree(description, &approved_tree, &parent, message, verbose)?;
         run_git_command(
-            "auto-approve earlier commits",
+            "update review ref to reconstructed approval",
             &[
-                "-c",
-                "rerere.enabled=false",
-                "merge",
-                "--squash",
-                "--ff",
-                "--quiet",
-                "--no-stat",
-                "-X",
-                "theirs",
+                "update-ref",
+                &format!("refs/heads/{review_branch}"),
+                &commit,
                 &parent,
             ],
             &[],
             verbose,
         )?;
-        run_git_command(
-            "commit auto-approved changes",
-            &["commit", "--quiet", "-m", "Auto-approve earlier commits"],
-            &[],
-            verbose,
-        )?;
-    }
+        commit
+    } else {
+        new_base.clone()
+    };
 
-    let target_commit = scope.end_oid.clone();
-
-    // Squash merge remaining changes
     run_git_command(
-        "squash merge remaining changes",
-        &[
-            "-c",
-            "rerere.enabled=false",
-            "merge",
-            "--squash",
-            "--ff",
-            "--quiet",
-            "--no-stat",
-            "-X",
-            "theirs",
-            &target_commit,
-        ],
+        "materialize review endpoint tree",
+        &["read-tree", "--reset", "-u", &scope.end_oid],
         &[],
         verbose,
     )?;
-
-    // Unstage changes for review
-    run_git_command("unstage changes for review", &["reset"], &[], verbose)?;
+    run_git_command(
+        "unstage changes for review",
+        &["reset", "--mixed", &new_review],
+        &[],
+        verbose,
+    )?;
     if is_new {
         write_review_metadata(&review_branch, &metadata, verbose)?;
     }
     write_review_scope(&review_branch, &scope, verbose)?;
-    Ok(!is_clean(verbose)?)
+    Ok(ReviewPreparation {
+        has_unreviewed_changes: !is_clean(verbose)?,
+    })
 }
 
 /// Commit reviewed changes and discard unreviewed ones
@@ -385,6 +479,71 @@ pub struct ReviewStatus {
     pub files: Vec<String>,
 }
 
+pub fn get_full_review_status(
+    metadata: &ReviewMetadata,
+    verbose: bool,
+) -> Result<ReviewStatus, ReviewError> {
+    let target = resolve_remote_tracking_branch(&metadata.target, verbose)?;
+    let source = resolve_remote_tracking_branch(&metadata.source, verbose)?;
+    let resolve = |description: &str, revision: &str| -> Result<String, ReviewError> {
+        let output = run_git_command(
+            description,
+            &["rev-parse", "--verify", &format!("{revision}^{{commit}}")],
+            &[],
+            verbose,
+        )?;
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    };
+    let target_oid = resolve("resolve current review target", &target.tracking_ref)?;
+    let source_oid = resolve("resolve current review source", &source.tracking_ref)?;
+    let review_head = resolve("resolve current review head", "HEAD")?;
+    let old_base = unique_merge_base(&review_head, &source_oid, verbose)?;
+    let new_base = unique_merge_base(&target_oid, &source_oid, verbose)?;
+
+    let object_path = run_git_command(
+        "locate Git object database",
+        &["rev-parse", "--git-path", "objects"],
+        &[],
+        verbose,
+    )?;
+    let object_path = PathBuf::from(String::from_utf8_lossy(&object_path.stdout).trim());
+    let object_path = if object_path.is_absolute() {
+        object_path
+    } else {
+        ReviewTransaction::repository_root(verbose)?.join(object_path)
+    };
+    let scratch = tempfile::TempDir::new().map_err(|error| {
+        ReviewError::Message(format!(
+            "failed to create temporary status reconstruction area: {error}"
+        ))
+    })?;
+    let scratch_objects = scratch.path().join("objects");
+    fs::create_dir(&scratch_objects).map_err(|error| {
+        ReviewError::Message(format!(
+            "failed to initialize temporary status object database: {error}"
+        ))
+    })?;
+    let env = [
+        ("GIT_OBJECT_DIRECTORY", scratch_objects.as_os_str()),
+        ("GIT_ALTERNATE_OBJECT_DIRECTORIES", object_path.as_os_str()),
+    ];
+    let reconstructed = reconstruct_approval_tree_with_env(
+        &old_base,
+        &new_base,
+        &review_head,
+        verbose,
+        Some(&env),
+    )?;
+    get_review_status_between(
+        &reconstructed.tree_oid,
+        &source_oid,
+        &format!("to {}", metadata.source),
+        verbose,
+        Some(&env),
+    )
+    .map_err(ReviewError::Git)
+}
+
 /// Get review status (remaining diff stats)
 ///
 /// # Arguments
@@ -401,12 +560,34 @@ pub fn get_review_status(
     display_label: &str,
     verbose: bool,
 ) -> Result<ReviewStatus, crate::git::GitCommandError> {
+    get_review_status_between("HEAD", compare_ref, display_label, verbose, None)
+}
+
+fn status_git(
+    description: &str,
+    args: &[&str],
+    verbose: bool,
+    env: Option<&[(&str, &OsStr)]>,
+) -> Result<std::process::Output, crate::git::GitCommandError> {
+    match env {
+        Some(env) => crate::git::run_git_command_with_env(description, args, env, &[], verbose),
+        None => run_git_command(description, args, &[], verbose),
+    }
+}
+
+fn get_review_status_between(
+    review_ref: &str,
+    compare_ref: &str,
+    display_label: &str,
+    verbose: bool,
+    env: Option<&[(&str, &OsStr)]>,
+) -> Result<ReviewStatus, crate::git::GitCommandError> {
     // Get diff stats summary (use HEAD..branch for direct comparison, not HEAD...branch)
-    let stat_output = run_git_command(
+    let stat_output = status_git(
         "get diff stats",
-        &["diff", "--stat", "HEAD", compare_ref],
-        &[],
+        &["diff", "--stat", review_ref, compare_ref],
         verbose,
+        env,
     )?;
     let stat_str = String::from_utf8_lossy(&stat_output.stdout);
 
@@ -435,11 +616,11 @@ pub fn get_review_status(
     }
 
     // Get list of changed files
-    let files_output = run_git_command(
+    let files_output = status_git(
         "get changed files",
-        &["diff", "--name-only", "HEAD", compare_ref],
-        &[],
+        &["diff", "--name-only", review_ref, compare_ref],
         verbose,
+        env,
     )?;
     let files: Vec<String> = String::from_utf8_lossy(&files_output.stdout)
         .lines()

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -160,7 +160,7 @@ fn prepare_review_plan(
     }
 
     let scope = ReviewScope {
-        base_oid: Some(new_base.clone()),
+        base_oid: new_base.clone(),
         end_oid: endpoint,
     };
 
@@ -199,21 +199,13 @@ fn prepare_review_plan(
             )
             .trim()
             .to_string();
-            let old_base = match read_review_scope(branch, verbose) {
-                Ok(saved) => match saved.base_oid {
-                    Some(base) => base,
-                    None => unique_merge_base(&old_review, &saved.end_oid, verbose)?,
-                },
-                Err(ReviewScopeError::Missing) => {
-                    unique_merge_base(&old_review, &tracking_from, verbose)?
-                }
-                Err(ReviewScopeError::Git(error)) => return Err(error.into()),
-                Err(error) => {
-                    return Err(ReviewError::Message(format!(
-                        "Cannot safely migrate existing review range metadata: {error:?}"
-                    )))
-                }
-            };
+            let saved = read_review_scope(branch, verbose).map_err(|error| match error {
+                ReviewScopeError::Git(error) => ReviewError::Git(error),
+                error => ReviewError::Message(format!(
+                    "Cannot read existing review range metadata: {error:?}"
+                )),
+            })?;
+            let old_base = saved.base_oid;
             (Some(old_review), Some(old_base))
         }
     };

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -4,8 +4,8 @@ use crate::git::{
     ReviewBranchSelectionError, ReviewMetadata, ReviewScope, ReviewScopeError,
 };
 use crate::review::{
-    reconstruct_approval_tree, review_commit_message, unique_merge_base, ReviewError,
-    ReviewPreparation, ReviewTransaction,
+    find_unique_merge_base, reconstruct_approval_tree, ReviewError, ReviewPreparation,
+    ReviewTransaction,
 };
 use std::ops::Not;
 
@@ -98,7 +98,7 @@ fn prepare_review_plan(
         &resolved_to.remote_branch,
         verbose,
     )?;
-    let new_base = unique_merge_base(&tracking_to, &endpoint, verbose)?;
+    let new_base = find_unique_merge_base(&tracking_to, &endpoint, verbose)?;
 
     let valid_commits = run_git_command(
         "get valid commit range",
@@ -303,7 +303,7 @@ fn merge_auto_approved_tree(
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
-fn commit_tree(
+fn create_commit_from_tree(
     description: &str,
     tree: &str,
     parent: &str,
@@ -374,18 +374,18 @@ fn apply_review_plan(plan: ReviewPlan, verbose: bool) -> Result<ReviewPreparatio
     }
 
     let new_review = if !is_new || auto_approve_parent.is_some() {
-        let subject = if is_new {
+        let message = if is_new {
             "Auto-approve earlier commits"
         } else {
             "Reconstruct approved changes"
         };
-        let message = review_commit_message(subject, &new_base);
         let description = if is_new {
             "commit auto-approved changes"
         } else {
             "commit reconstructed approved tree"
         };
-        let commit = commit_tree(description, &approved_tree, &parent, &message, verbose)?;
+        let commit =
+            create_commit_from_tree(description, &approved_tree, &parent, message, verbose)?;
         run_git_command(
             "update review ref to reconstructed approval",
             &[

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -4,8 +4,8 @@ use crate::git::{
     ReviewBranchSelectionError, ReviewMetadata, ReviewScope, ReviewScopeError,
 };
 use crate::review::{
-    reconstruct_approval_tree, reconstruct_approval_tree_with_env, unique_merge_base, ReviewError,
-    ReviewPreparation, ReviewTransaction,
+    explicit_review_base, reconstruct_approval_tree, reconstruct_approval_tree_with_env,
+    review_commit_message, unique_merge_base, ReviewError, ReviewPreparation, ReviewTransaction,
 };
 use std::ffi::OsStr;
 use std::ops::Not;
@@ -22,7 +22,7 @@ struct ReviewPlan {
     tracking_updates: Vec<(String, String)>,
 }
 
-/// Prepare the review branch using Squash Merge approach.
+/// Prepare a review branch with explicit approval-tree reconstruction.
 ///
 /// # Arguments
 ///
@@ -384,17 +384,18 @@ fn apply_review_plan(plan: ReviewPlan, verbose: bool) -> Result<ReviewPreparatio
     }
 
     let new_review = if !is_new || auto_approve_parent.is_some() {
-        let message = if is_new {
+        let subject = if is_new {
             "Auto-approve earlier commits"
         } else {
             "Reconstruct approved changes"
         };
+        let message = review_commit_message(subject, &new_base);
         let description = if is_new {
             "commit auto-approved changes"
         } else {
             "commit reconstructed approved tree"
         };
-        let commit = commit_tree(description, &approved_tree, &parent, message, verbose)?;
+        let commit = commit_tree(description, &approved_tree, &parent, &message, verbose)?;
         run_git_command(
             "update review ref to reconstructed approval",
             &[
@@ -497,7 +498,10 @@ pub fn get_full_review_status(
     let target_oid = resolve("resolve current review target", &target.tracking_ref)?;
     let source_oid = resolve("resolve current review source", &source.tracking_ref)?;
     let review_head = resolve("resolve current review head", "HEAD")?;
-    let old_base = unique_merge_base(&review_head, &source_oid, verbose)?;
+    let old_base = match explicit_review_base(&review_head, verbose)? {
+        Some(base) => base,
+        None => unique_merge_base(&review_head, &source_oid, verbose)?,
+    };
     let new_base = unique_merge_base(&target_oid, &source_oid, verbose)?;
 
     let object_path = run_git_command(

--- a/src/git.rs
+++ b/src/git.rs
@@ -331,10 +331,16 @@ pub fn read_review_scope(branch: &str, verbose: bool) -> Result<ReviewScope, Rev
         .lines()
         .map(str::to_owned)
         .collect();
-    if results.iter().any(|result| result.ends_with(" missing")) {
-        return Err(ReviewScopeError::UnavailableCommit(end_oid.to_string()));
-    }
     let expected: Vec<_> = base_oid.into_iter().chain([end_oid]).collect();
+    if let Some((_, missing_oid)) = results
+        .iter()
+        .zip(&expected)
+        .find(|(result, _)| result.ends_with(" missing"))
+    {
+        return Err(ReviewScopeError::UnavailableCommit(
+            (*missing_oid).to_string(),
+        ));
+    }
     if results != expected {
         return Err(ReviewScopeError::Invalid);
     }

--- a/src/git.rs
+++ b/src/git.rs
@@ -13,7 +13,7 @@ pub struct GitCommandError {
 }
 
 pub const REVIEW_METADATA_VERSION: &str = "1";
-pub const REVIEW_SCOPE_VERSION: &str = "2";
+pub const REVIEW_SCOPE_VERSION: &str = "1";
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ReviewMetadata {
@@ -23,7 +23,7 @@ pub struct ReviewMetadata {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ReviewScope {
-    pub base_oid: Option<String>,
+    pub base_oid: String,
     pub end_oid: String,
 }
 
@@ -272,11 +272,10 @@ pub fn write_review_scope(
     verbose: bool,
 ) -> Result<(), GitCommandError> {
     let key = review_config_key(branch, "scope");
-    let base_oid = scope
-        .base_oid
-        .as_deref()
-        .expect("successful review scopes must include an explicit base");
-    let value = format!("{}:{}:{}", REVIEW_SCOPE_VERSION, base_oid, scope.end_oid);
+    let value = format!(
+        "{}:{}:{}",
+        REVIEW_SCOPE_VERSION, scope.base_oid, scope.end_oid
+    );
     run_git_command(
         "record review range",
         &["config", "--local", "--replace-all", &key, &value],
@@ -294,31 +293,21 @@ pub fn read_review_scope(branch: &str, verbose: bool) -> Result<ReviewScope, Rev
         _ => return Err(ReviewScopeError::Duplicate),
     };
     let mut fields = value.split(':');
-    let Some(version) = fields.next() else {
+    let (Some(version), Some(base_oid), Some(end_oid), None) =
+        (fields.next(), fields.next(), fields.next(), fields.next())
+    else {
         return Err(ReviewScopeError::Invalid);
     };
-    let (base_oid, end_oid) = match version {
-        "1" => (None, fields.next()),
-        REVIEW_SCOPE_VERSION => (fields.next(), fields.next()),
-        _ => return Err(ReviewScopeError::UnsupportedVersion(version.to_string())),
-    };
-    if fields.next().is_some() {
-        return Err(ReviewScopeError::Invalid);
+    if version != REVIEW_SCOPE_VERSION {
+        return Err(ReviewScopeError::UnsupportedVersion(version.to_string()));
     }
-    let Some(end_oid) = end_oid else {
-        return Err(ReviewScopeError::Invalid);
-    };
     let valid_oid = |oid: &str| {
         !oid.is_empty() && oid.len() == 40 && oid.bytes().all(|byte| byte.is_ascii_hexdigit())
     };
-    if !valid_oid(end_oid) || base_oid.is_some_and(|oid| !valid_oid(oid)) {
+    if !valid_oid(base_oid) || !valid_oid(end_oid) {
         return Err(ReviewScopeError::Invalid);
     }
-    let mut revisions = String::new();
-    if let Some(base_oid) = base_oid {
-        revisions.push_str(&format!("{base_oid}^{{commit}}\n"));
-    }
-    revisions.push_str(&format!("{end_oid}^{{commit}}\n"));
+    let revisions = format!("{base_oid}^{{commit}}\n{end_oid}^{{commit}}\n");
     let output = run_git_command_with_input(
         "validate review range endpoint",
         &["cat-file", "--batch-check=%(objectname)"],
@@ -331,7 +320,7 @@ pub fn read_review_scope(branch: &str, verbose: bool) -> Result<ReviewScope, Rev
         .lines()
         .map(str::to_owned)
         .collect();
-    let expected: Vec<_> = base_oid.into_iter().chain([end_oid]).collect();
+    let expected = [base_oid, end_oid];
     if let Some((_, missing_oid)) = results
         .iter()
         .zip(&expected)
@@ -345,7 +334,7 @@ pub fn read_review_scope(branch: &str, verbose: bool) -> Result<ReviewScope, Rev
         return Err(ReviewScopeError::Invalid);
     }
     Ok(ReviewScope {
-        base_oid: base_oid.map(str::to_string),
+        base_oid: base_oid.to_string(),
         end_oid: end_oid.to_string(),
     })
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,4 +1,5 @@
 use colored::Colorize;
+use std::ffi::OsStr;
 use std::io::Write;
 use std::process::{Command, ExitStatus, Output, Stdio};
 
@@ -12,7 +13,7 @@ pub struct GitCommandError {
 }
 
 pub const REVIEW_METADATA_VERSION: &str = "1";
-pub const REVIEW_SCOPE_VERSION: &str = "1";
+pub const REVIEW_SCOPE_VERSION: &str = "2";
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ReviewMetadata {
@@ -22,6 +23,7 @@ pub struct ReviewMetadata {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ReviewScope {
+    pub base_oid: Option<String>,
     pub end_oid: String,
 }
 
@@ -270,7 +272,11 @@ pub fn write_review_scope(
     verbose: bool,
 ) -> Result<(), GitCommandError> {
     let key = review_config_key(branch, "scope");
-    let value = format!("{}:{}", REVIEW_SCOPE_VERSION, scope.end_oid);
+    let base_oid = scope
+        .base_oid
+        .as_deref()
+        .expect("successful review scopes must include an explicit base");
+    let value = format!("{}:{}:{}", REVIEW_SCOPE_VERSION, base_oid, scope.end_oid);
     run_git_command(
         "record review range",
         &["config", "--local", "--replace-all", &key, &value],
@@ -287,35 +293,53 @@ pub fn read_review_scope(branch: &str, verbose: bool) -> Result<ReviewScope, Rev
         [value] => value,
         _ => return Err(ReviewScopeError::Duplicate),
     };
-    let Some((version, end_oid)) = value.split_once(':') else {
+    let mut fields = value.split(':');
+    let Some(version) = fields.next() else {
         return Err(ReviewScopeError::Invalid);
     };
-    if version != REVIEW_SCOPE_VERSION {
-        return Err(ReviewScopeError::UnsupportedVersion(version.to_string()));
-    }
-    if end_oid.is_empty()
-        || end_oid.contains(':')
-        || !end_oid.bytes().all(|byte| byte.is_ascii_hexdigit())
-    {
+    let (base_oid, end_oid) = match version {
+        "1" => (None, fields.next()),
+        REVIEW_SCOPE_VERSION => (fields.next(), fields.next()),
+        _ => return Err(ReviewScopeError::UnsupportedVersion(version.to_string())),
+    };
+    if fields.next().is_some() {
         return Err(ReviewScopeError::Invalid);
     }
-    let revision = format!("{end_oid}^{{commit}}\n");
+    let Some(end_oid) = end_oid else {
+        return Err(ReviewScopeError::Invalid);
+    };
+    let valid_oid = |oid: &str| {
+        !oid.is_empty() && oid.len() == 40 && oid.bytes().all(|byte| byte.is_ascii_hexdigit())
+    };
+    if !valid_oid(end_oid) || base_oid.is_some_and(|oid| !valid_oid(oid)) {
+        return Err(ReviewScopeError::Invalid);
+    }
+    let mut revisions = String::new();
+    if let Some(base_oid) = base_oid {
+        revisions.push_str(&format!("{base_oid}^{{commit}}\n"));
+    }
+    revisions.push_str(&format!("{end_oid}^{{commit}}\n"));
     let output = run_git_command_with_input(
         "validate review range endpoint",
         &["cat-file", "--batch-check=%(objectname)"],
-        revision.as_bytes(),
+        revisions.as_bytes(),
         &[],
         verbose,
     )
     .map_err(ReviewScopeError::Git)?;
-    let result = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if result.ends_with(" missing") {
+    let results: Vec<_> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::to_owned)
+        .collect();
+    if results.iter().any(|result| result.ends_with(" missing")) {
         return Err(ReviewScopeError::UnavailableCommit(end_oid.to_string()));
     }
-    if result != end_oid {
+    let expected: Vec<_> = base_oid.into_iter().chain([end_oid]).collect();
+    if results != expected {
         return Err(ReviewScopeError::Invalid);
     }
     Ok(ReviewScope {
+        base_oid: base_oid.map(str::to_string),
         end_oid: end_oid.to_string(),
     })
 }
@@ -345,6 +369,30 @@ pub fn run_git_command(
     command.args(args);
     if args.first() == Some(&"status") {
         command.env("GIT_OPTIONAL_LOCKS", "0");
+    }
+    evaluate_git_output(
+        description,
+        args,
+        allowed_exit_codes,
+        verbose,
+        command.output(),
+    )
+}
+
+pub fn run_git_command_with_env(
+    description: &str,
+    args: &[&str],
+    env: &[(&str, &OsStr)],
+    allowed_exit_codes: &[i32],
+    verbose: bool,
+) -> Result<Output, GitCommandError> {
+    if verbose {
+        println!("[git {}]", args.join(" ").yellow());
+    }
+    let mut command = Command::new("git");
+    command.args(args);
+    for (key, value) in env {
+        command.env(key, value);
     }
     evaluate_git_output(
         description,

--- a/src/main.rs
+++ b/src/main.rs
@@ -214,7 +214,7 @@ fn exit_invalid_review_scope(error: ReviewScopeError, metadata: &ReviewMetadata)
         }
     };
     eprintln!(
-        "{}: Cannot show current review range because {}. Rerun `cresca review {} {}` to record the range.",
+        "{}: Cannot show current review range because {}. This review branch must be recreated. Switch away from it, delete it, then run `cresca review {} {}`.",
         "error".red().bold(),
         reason,
         metadata.target,

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,10 +5,10 @@ mod review;
 use clap::builder::styling::{AnsiColor, Effects};
 use clap::{builder::Styles, ArgAction, Args, Parser, Subcommand};
 use colored::Colorize;
-use commands::{approve_changes, get_review_status, prepare_review_branch};
+use commands::{approve_changes, get_full_review_status, get_review_status, prepare_review_branch};
 use git::{
-    current_branch_name, current_review_metadata, read_review_scope,
-    resolve_remote_tracking_branch, ReviewMetadata, ReviewMetadataError, ReviewScopeError,
+    current_branch_name, current_review_metadata, read_review_scope, ReviewMetadata,
+    ReviewMetadataError, ReviewScopeError,
 };
 use std::process::exit;
 
@@ -115,14 +115,14 @@ fn run() -> Result<(), CliError> {
             };
         }
         Commands::Review(args) => {
-            let has_unreviewed_changes = prepare_review_branch(
+            let preparation = prepare_review_branch(
                 &args.to,
                 &args.from,
                 args.skip_to.as_deref(),
                 args.stop_at.as_deref(),
                 cli.verbose,
             )?;
-            if !has_unreviewed_changes {
+            if !preparation.has_unreviewed_changes {
                 println!("Review branch prepared successfully. However, it seems like there are no unreviewed changes.");
             } else {
                 println!("Review branch prepared successfully. Stage the changes you have reviewed and run `{}` to approve them.", "cresca approve".green());
@@ -134,12 +134,10 @@ fn run() -> Result<(), CliError> {
                 Err(ReviewMetadataError::Git(error)) => return Err(error.into()),
                 Err(error) => exit_invalid_review_branch(error),
             };
-            let (heading, compare_ref, display_label) = if args.all {
-                let resolved = resolve_remote_tracking_branch(&metadata.source, cli.verbose)?;
+            let (heading, status) = if args.all {
                 (
                     "full pull request",
-                    resolved.tracking_ref,
-                    format!("to {}", metadata.source),
+                    get_full_review_status(&metadata, cli.verbose)?,
                 )
             } else {
                 let branch = current_branch_name(cli.verbose)?;
@@ -148,13 +146,10 @@ fn run() -> Result<(), CliError> {
                     Err(ReviewScopeError::Git(error)) => return Err(error.into()),
                     Err(error) => exit_invalid_review_scope(error, &metadata),
                 };
-                (
-                    "current range",
-                    scope.end_oid,
-                    "in current review range".to_string(),
-                )
+                let status =
+                    get_review_status(&scope.end_oid, "in current review range", cli.verbose)?;
+                ("current range", status)
             };
-            let status = get_review_status(&compare_ref, &display_label, cli.verbose)?;
             println!("📋 Review status ({}):", heading);
             println!(
                 "  Remaining diff {}: {} file(s), {} insertion(s), {} deletion(s)",

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ mod review;
 use clap::builder::styling::{AnsiColor, Effects};
 use clap::{builder::Styles, ArgAction, Args, Parser, Subcommand};
 use colored::Colorize;
-use commands::{approve_changes, get_full_review_status, get_review_status, prepare_review_branch};
+use commands::{approve_changes, get_review_status, prepare_review_branch};
 use git::{
     current_branch_name, current_review_metadata, read_review_scope, ReviewMetadata,
     ReviewMetadataError, ReviewScopeError,
@@ -65,14 +65,7 @@ enum Commands {
     /// Prepare a review branch.
     Review(ReviewArgs),
     /// Show remaining diff statistics.
-    Status(StatusArgs),
-}
-
-#[derive(Args)]
-struct StatusArgs {
-    /// Show unapproved changes across the full pull request.
-    #[arg(long)]
-    all: bool,
+    Status,
 }
 
 #[derive(Args)]
@@ -128,29 +121,20 @@ fn run() -> Result<(), CliError> {
                 println!("Review branch prepared successfully. Stage the changes you have reviewed and run `{}` to approve them.", "cresca approve".green());
             }
         }
-        Commands::Status(args) => {
+        Commands::Status => {
             let metadata = match current_review_metadata(cli.verbose) {
                 Ok(metadata) => metadata,
                 Err(ReviewMetadataError::Git(error)) => return Err(error.into()),
                 Err(error) => exit_invalid_review_branch(error),
             };
-            let (heading, status) = if args.all {
-                (
-                    "full pull request",
-                    get_full_review_status(&metadata, cli.verbose)?,
-                )
-            } else {
-                let branch = current_branch_name(cli.verbose)?;
-                let scope = match read_review_scope(&branch, cli.verbose) {
-                    Ok(scope) => scope,
-                    Err(ReviewScopeError::Git(error)) => return Err(error.into()),
-                    Err(error) => exit_invalid_review_scope(error, &metadata),
-                };
-                let status =
-                    get_review_status(&scope.end_oid, "in current review range", cli.verbose)?;
-                ("current range", status)
+            let branch = current_branch_name(cli.verbose)?;
+            let scope = match read_review_scope(&branch, cli.verbose) {
+                Ok(scope) => scope,
+                Err(ReviewScopeError::Git(error)) => return Err(error.into()),
+                Err(error) => exit_invalid_review_scope(error, &metadata),
             };
-            println!("📋 Review status ({}):", heading);
+            let status = get_review_status(&scope.end_oid, "in current review range", cli.verbose)?;
+            println!("📋 Review status (current range):");
             println!(
                 "  Remaining diff {}: {} file(s), {} insertion(s), {} deletion(s)",
                 status.display_label,
@@ -230,7 +214,7 @@ fn exit_invalid_review_scope(error: ReviewScopeError, metadata: &ReviewMetadata)
         }
     };
     eprintln!(
-        "{}: Cannot show current review range because {}. Rerun `cresca review {} {}` to record the range. `cresca status --all` is still available.",
+        "{}: Cannot show current review range because {}. Rerun `cresca review {} {}` to record the range.",
         "error".red().bold(),
         reason,
         metadata.target,

--- a/src/main.rs
+++ b/src/main.rs
@@ -222,7 +222,7 @@ fn exit_invalid_review_scope(error: ReviewScopeError, metadata: &ReviewMetadata)
         }
         ReviewScopeError::Invalid => "range metadata is invalid".to_string(),
         ReviewScopeError::UnavailableCommit(oid) => {
-            format!("saved range endpoint '{oid}' is unavailable")
+            format!("saved review object '{oid}' is unavailable")
         }
         ReviewScopeError::Git(error) => {
             render_git_error(&error);

--- a/src/review.rs
+++ b/src/review.rs
@@ -159,7 +159,8 @@ fn read_tree_entries(
         let mode = fields.next().unwrap_or_default();
         let kind = fields.next().unwrap_or_default();
         let oid = fields.next().unwrap_or_default();
-        if kind != "blob" || mode.is_empty() || oid.is_empty() {
+        let is_supported_leaf = kind == "blob" || (kind == "commit" && mode == "160000");
+        if !is_supported_leaf || mode.is_empty() || oid.is_empty() {
             continue;
         }
         entries.insert(

--- a/src/review.rs
+++ b/src/review.rs
@@ -247,18 +247,32 @@ fn ambiguous_exact_rename_paths(
     verbose: bool,
     env: Option<&[(&str, &OsStr)]>,
 ) -> Result<Vec<String>, ReviewError> {
+    let correspondence_key = |entry: &(String, String)| {
+        let compatible_type = if entry.0 == "100644" || entry.0 == "100755" {
+            "regular".to_string()
+        } else {
+            entry.0.clone()
+        };
+        (compatible_type, entry.1.clone())
+    };
     let base = tree_entries(old_base, verbose, env)?;
     let review = tree_entries(old_review, verbose, env)?;
     let mut removed: BTreeMap<(String, String), Vec<&[u8]>> = BTreeMap::new();
     let mut added: BTreeMap<(String, String), Vec<&[u8]>> = BTreeMap::new();
     for (path, entry) in &base {
         if !review.contains_key(path) {
-            removed.entry(entry.clone()).or_default().push(path);
+            removed
+                .entry(correspondence_key(entry))
+                .or_default()
+                .push(path);
         }
     }
     for (path, entry) in &review {
         if !base.contains_key(path) {
-            added.entry(entry.clone()).or_default().push(path);
+            added
+                .entry(correspondence_key(entry))
+                .or_default()
+                .push(path);
         }
     }
 

--- a/src/review.rs
+++ b/src/review.rs
@@ -61,11 +61,19 @@ pub fn unique_merge_base(left: &str, right: &str, verbose: bool) -> Result<Strin
 
 pub fn explicit_review_base(
     review_head: &str,
+    current_base: &str,
     verbose: bool,
 ) -> Result<Option<String>, ReviewError> {
+    let excluded_base = format!("^{current_base}");
     let output = run_git_command(
         "find explicit review base",
-        &["log", "--first-parent", "--format=%B%x00", review_head],
+        &[
+            "log",
+            "--first-parent",
+            "--format=%B%x00",
+            review_head,
+            &excluded_base,
+        ],
         &[],
         verbose,
     )?;
@@ -193,6 +201,91 @@ fn tree_entry(
     Ok(Some((mode, oid)))
 }
 
+fn tree_entries(
+    revision: &str,
+    verbose: bool,
+    env: Option<&[(&str, &OsStr)]>,
+) -> Result<BTreeMap<Vec<u8>, (String, String)>, ReviewError> {
+    let output = reconstruction_git(
+        "inspect reconstruction tree",
+        &["ls-tree", "-rz", revision],
+        &[],
+        verbose,
+        env,
+    )?;
+    let mut entries = BTreeMap::new();
+    for record in output.stdout.split(|byte| *byte == 0) {
+        if record.is_empty() {
+            continue;
+        }
+        let Some(tab) = record.iter().position(|byte| *byte == b'\t') else {
+            return Err(ReviewError::Message(
+                "Git returned an invalid recursive tree entry.".to_string(),
+            ));
+        };
+        let header = std::str::from_utf8(&record[..tab]).map_err(|_| {
+            ReviewError::Message("Git returned a non-UTF-8 tree entry header.".to_string())
+        })?;
+        let mut fields = header.split_whitespace();
+        let mode = fields.next().unwrap_or_default();
+        let kind = fields.next().unwrap_or_default();
+        let oid = fields.next().unwrap_or_default();
+        if kind != "blob" || mode.is_empty() || oid.is_empty() {
+            continue;
+        }
+        entries.insert(
+            record[tab + 1..].to_vec(),
+            (mode.to_string(), oid.to_string()),
+        );
+    }
+    Ok(entries)
+}
+
+fn ambiguous_exact_rename_paths(
+    old_base: &str,
+    old_review: &str,
+    verbose: bool,
+    env: Option<&[(&str, &OsStr)]>,
+) -> Result<Vec<String>, ReviewError> {
+    let base = tree_entries(old_base, verbose, env)?;
+    let review = tree_entries(old_review, verbose, env)?;
+    let mut removed: BTreeMap<(String, String), Vec<&[u8]>> = BTreeMap::new();
+    let mut added: BTreeMap<(String, String), Vec<&[u8]>> = BTreeMap::new();
+    for (path, entry) in &base {
+        if !review.contains_key(path) {
+            removed.entry(entry.clone()).or_default().push(path);
+        }
+    }
+    for (path, entry) in &review {
+        if !base.contains_key(path) {
+            added.entry(entry.clone()).or_default().push(path);
+        }
+    }
+
+    let mut ambiguous = BTreeSet::new();
+    for (entry, removed_paths) in removed {
+        let Some(added_paths) = added.get(&entry) else {
+            continue;
+        };
+        if removed_paths.len() * added_paths.len() <= 1 {
+            continue;
+        }
+        ambiguous.extend(removed_paths);
+        ambiguous.extend(added_paths.iter().copied());
+    }
+    ambiguous
+        .into_iter()
+        .map(|path| {
+            std::str::from_utf8(path).map(str::to_string).map_err(|_| {
+                ReviewError::Message(
+                    "Git found ambiguous exact renames with a non-UTF-8 path; refusing the reconstructed tree."
+                        .to_string(),
+                )
+            })
+        })
+        .collect()
+}
+
 fn is_binary_blob(
     oid: &str,
     verbose: bool,
@@ -303,7 +396,7 @@ pub fn reconstruct_approval_tree_with_env(
         ));
     }
 
-    let mut downgraded = Vec::new();
+    let mut downgraded = ambiguous_exact_rename_paths(old_base, old_review, verbose, env)?;
     for path in &conflict_paths {
         if merged.status.code() == Some(1)
             || !text_conflict_can_keep_hunks(old_base, new_base, old_review, path, verbose, env)?

--- a/src/review.rs
+++ b/src/review.rs
@@ -61,10 +61,10 @@ pub fn unique_merge_base(left: &str, right: &str, verbose: bool) -> Result<Strin
 
 pub fn explicit_review_base(
     review_head: &str,
-    current_base: &str,
+    current_target: &str,
     verbose: bool,
 ) -> Result<Option<String>, ReviewError> {
-    let excluded_base = format!("^{current_base}");
+    let excluded_target = format!("^{current_target}");
     let output = run_git_command(
         "find explicit review base",
         &[
@@ -72,7 +72,7 @@ pub fn explicit_review_base(
             "--first-parent",
             "--format=%B%x00",
             review_head,
-            &excluded_base,
+            &excluded_target,
         ],
         &[],
         verbose,
@@ -173,7 +173,7 @@ fn tree_entry(
 ) -> Result<Option<(String, String)>, ReviewError> {
     let output = reconstruction_git(
         "inspect reconstruction tree entry",
-        &["ls-tree", "-z", revision, "--", path],
+        &["--literal-pathspecs", "ls-tree", "-z", revision, "--", path],
         &[],
         verbose,
         env,
@@ -410,7 +410,10 @@ pub fn reconstruct_approval_tree_with_env(
         ));
     }
 
-    let mut downgraded = ambiguous_exact_rename_paths(old_base, old_review, verbose, env)?;
+    let mut downgraded = ambiguous_exact_rename_paths(old_base, new_base, verbose, env)?;
+    downgraded.extend(ambiguous_exact_rename_paths(
+        old_base, old_review, verbose, env,
+    )?);
     for path in &conflict_paths {
         if merged.status.code() == Some(1)
             || !text_conflict_can_keep_hunks(old_base, new_base, old_review, path, verbose, env)?
@@ -444,7 +447,7 @@ pub fn reconstruct_approval_tree_with_env(
     for path in &downgraded {
         run_git_command_with_env(
             "downgrade conflicted path to new base",
-            &["reset", new_base, "--", path],
+            &["--literal-pathspecs", "reset", new_base, "--", path],
             &scratch_env,
             &[],
             verbose,

--- a/src/review.rs
+++ b/src/review.rs
@@ -1,10 +1,22 @@
-use crate::git::{run_git_command, GitCommandError};
+use crate::git::{run_git_command, run_git_command_with_env, GitCommandError};
 use std::collections::{BTreeMap, BTreeSet};
+use std::ffi::OsStr;
 use std::fs;
 use std::io::{self, Read};
 use std::os::unix::fs::{symlink, MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ReviewPreparation {
+    pub has_unreviewed_changes: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ReconstructionOutcome {
+    pub tree_oid: String,
+    pub downgraded_paths: Vec<String>,
+}
 
 #[derive(Debug)]
 pub enum ReviewError {
@@ -20,6 +32,259 @@ impl From<GitCommandError> for ReviewError {
     fn from(error: GitCommandError) -> Self {
         Self::Git(error)
     }
+}
+
+pub fn unique_merge_base(left: &str, right: &str, verbose: bool) -> Result<String, ReviewError> {
+    let output = run_git_command(
+        "get unique merge base",
+        &["merge-base", "--all", left, right],
+        &[1],
+        verbose,
+    )?;
+    let bases: Vec<_> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(str::to_owned)
+        .collect();
+    match bases.as_slice() {
+        [base] => Ok(base.clone()),
+        [] => Err(ReviewError::Message(format!(
+            "No unique safe merge base exists between `{left}` and `{right}`."
+        ))),
+        _ => Err(ReviewError::Message(format!(
+            "Multiple merge bases exist between `{left}` and `{right}`; refusing to guess approval history."
+        ))),
+    }
+}
+
+fn parse_merge_tree_output(stdout: &[u8]) -> (Option<String>, Vec<String>) {
+    let mut fields = stdout.split(|byte| *byte == 0);
+    let tree = fields
+        .next()
+        .and_then(|field| std::str::from_utf8(field).ok())
+        .map(str::trim)
+        .filter(|field| !field.is_empty())
+        .map(str::to_owned);
+    let mut paths = Vec::new();
+    for field in fields {
+        if field.is_empty() {
+            break;
+        }
+        paths.push(String::from_utf8_lossy(field).into_owned());
+    }
+    (tree, paths)
+}
+
+fn reconstruction_git(
+    description: &str,
+    args: &[&str],
+    allowed_exit_codes: &[i32],
+    verbose: bool,
+    env: Option<&[(&str, &OsStr)]>,
+) -> Result<std::process::Output, GitCommandError> {
+    match env {
+        Some(env) => run_git_command_with_env(description, args, env, allowed_exit_codes, verbose),
+        None => run_git_command(description, args, allowed_exit_codes, verbose),
+    }
+}
+
+fn tree_entry(
+    revision: &str,
+    path: &str,
+    verbose: bool,
+    env: Option<&[(&str, &OsStr)]>,
+) -> Result<Option<(String, String)>, ReviewError> {
+    let output = reconstruction_git(
+        "inspect reconstruction tree entry",
+        &["ls-tree", "-z", revision, "--", path],
+        &[],
+        verbose,
+        env,
+    )?;
+    if output.stdout.is_empty() {
+        return Ok(None);
+    }
+    let record = output
+        .stdout
+        .split(|byte| *byte == 0)
+        .next()
+        .unwrap_or_default();
+    let header = record
+        .split(|byte| *byte == b'\t')
+        .next()
+        .ok_or_else(|| ReviewError::Message("Git returned an invalid tree entry".to_string()))?;
+    let header = String::from_utf8_lossy(header);
+    let mut fields = header.split_whitespace();
+    let mode = fields.next().unwrap_or_default().to_string();
+    let kind = fields.next().unwrap_or_default();
+    let oid = fields.next().unwrap_or_default().to_string();
+    if kind != "blob" || mode.is_empty() || oid.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some((mode, oid)))
+}
+
+fn is_binary_blob(
+    oid: &str,
+    verbose: bool,
+    env: Option<&[(&str, &OsStr)]>,
+) -> Result<bool, ReviewError> {
+    let output = reconstruction_git(
+        "inspect conflicting blob",
+        &["cat-file", "blob", oid],
+        &[],
+        verbose,
+        env,
+    )?;
+    Ok(output.stdout.contains(&0))
+}
+
+fn text_conflict_can_keep_hunks(
+    old_base: &str,
+    new_base: &str,
+    old_review: &str,
+    path: &str,
+    verbose: bool,
+    env: Option<&[(&str, &OsStr)]>,
+) -> Result<bool, ReviewError> {
+    let Some(old) = tree_entry(old_base, path, verbose, env)? else {
+        return Ok(false);
+    };
+    let Some(new) = tree_entry(new_base, path, verbose, env)? else {
+        return Ok(false);
+    };
+    let Some(review) = tree_entry(old_review, path, verbose, env)? else {
+        return Ok(false);
+    };
+    let regular = |mode: &str| mode == "100644" || mode == "100755";
+    if old.0 != new.0 || old.0 != review.0 || !regular(&old.0) {
+        return Ok(false);
+    }
+    Ok(!is_binary_blob(&old.1, verbose, env)?
+        && !is_binary_blob(&new.1, verbose, env)?
+        && !is_binary_blob(&review.1, verbose, env)?)
+}
+
+pub fn reconstruct_approval_tree(
+    old_base: &str,
+    new_base: &str,
+    old_review: &str,
+    verbose: bool,
+) -> Result<ReconstructionOutcome, ReviewError> {
+    reconstruct_approval_tree_with_env(old_base, new_base, old_review, verbose, None)
+}
+
+pub fn reconstruct_approval_tree_with_env(
+    old_base: &str,
+    new_base: &str,
+    old_review: &str,
+    verbose: bool,
+    env: Option<&[(&str, &OsStr)]>,
+) -> Result<ReconstructionOutcome, ReviewError> {
+    let diagnostic = reconstruction_git(
+        "identify approval reconstruction conflicts",
+        &[
+            "merge-tree",
+            "--write-tree",
+            &format!("--merge-base={old_base}"),
+            "-Xfind-renames=100%",
+            "--messages",
+            "--name-only",
+            "-z",
+            new_base,
+            old_review,
+        ],
+        &[1],
+        verbose,
+        env,
+    )?;
+    let (_, conflict_paths) = parse_merge_tree_output(&diagnostic.stdout);
+    if diagnostic.status.code() == Some(1) && conflict_paths.is_empty() {
+        return Err(ReviewError::Message(
+            "Approval reconstruction conflicted but Git did not identify any paths; refusing the reconstructed tree."
+                .to_string(),
+        ));
+    }
+
+    let merged = reconstruction_git(
+        "reconstruct approved tree",
+        &[
+            "merge-tree",
+            "--write-tree",
+            &format!("--merge-base={old_base}"),
+            "-Xours",
+            "-Xfind-renames=100%",
+            "--no-messages",
+            new_base,
+            old_review,
+        ],
+        &[1],
+        verbose,
+        env,
+    )?;
+    let tree_oid = String::from_utf8_lossy(&merged.stdout)
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    if tree_oid.is_empty() {
+        return Err(ReviewError::Message(
+            "Git did not return a reconstructed approval tree.".to_string(),
+        ));
+    }
+
+    let mut downgraded = Vec::new();
+    for path in &conflict_paths {
+        if merged.status.code() == Some(1)
+            || !text_conflict_can_keep_hunks(old_base, new_base, old_review, path, verbose, env)?
+        {
+            downgraded.push(path.clone());
+        }
+    }
+    downgraded.sort();
+    downgraded.dedup();
+    if downgraded.is_empty() {
+        return Ok(ReconstructionOutcome {
+            tree_oid,
+            downgraded_paths: downgraded,
+        });
+    }
+
+    let scratch = TempDir::new().map_err(|error| {
+        ReviewError::Message(format!("failed to create scratch index: {error}"))
+    })?;
+    let index = scratch.path().join("index");
+    let mut scratch_env: Vec<(&str, &OsStr)> = env.unwrap_or_default().to_vec();
+    scratch_env.retain(|(key, _)| *key != "GIT_INDEX_FILE");
+    scratch_env.push(("GIT_INDEX_FILE", index.as_os_str()));
+    run_git_command_with_env(
+        "load reconstructed tree into scratch index",
+        &["read-tree", &tree_oid],
+        &scratch_env,
+        &[],
+        verbose,
+    )?;
+    for path in &downgraded {
+        run_git_command_with_env(
+            "downgrade conflicted path to new base",
+            &["reset", new_base, "--", path],
+            &scratch_env,
+            &[],
+            verbose,
+        )?;
+    }
+    let output = run_git_command_with_env(
+        "write reconstructed scratch index",
+        &["write-tree"],
+        &scratch_env,
+        &[],
+        verbose,
+    )?;
+    Ok(ReconstructionOutcome {
+        tree_oid: String::from_utf8_lossy(&output.stdout).trim().to_string(),
+        downgraded_paths: downgraded,
+    })
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/review.rs
+++ b/src/review.rs
@@ -18,6 +18,8 @@ pub struct ReconstructionOutcome {
     pub downgraded_paths: Vec<String>,
 }
 
+const REVIEW_BASE_TRAILER: &str = "Cresca-Review-Base: ";
+
 #[derive(Debug)]
 pub enum ReviewError {
     Git(GitCommandError),
@@ -57,11 +59,72 @@ pub fn unique_merge_base(left: &str, right: &str, verbose: bool) -> Result<Strin
     }
 }
 
-fn parse_merge_tree_output(stdout: &[u8]) -> (Option<String>, Vec<String>) {
+pub fn explicit_review_base(
+    review_head: &str,
+    verbose: bool,
+) -> Result<Option<String>, ReviewError> {
+    let output = run_git_command(
+        "find explicit review base",
+        &["log", "--first-parent", "--format=%B%x00", review_head],
+        &[],
+        verbose,
+    )?;
+    for message in output.stdout.split(|byte| *byte == 0) {
+        let message = std::str::from_utf8(message).map_err(|_| {
+            ReviewError::Message(
+                "Review history contains a non-UTF-8 commit message; refusing to infer its approval base."
+                    .to_string(),
+            )
+        })?;
+        let markers: Vec<_> = message
+            .lines()
+            .filter_map(|line| line.strip_prefix(REVIEW_BASE_TRAILER))
+            .collect();
+        if markers.is_empty() {
+            continue;
+        }
+        let [base] = markers.as_slice() else {
+            return Err(ReviewError::Message(
+                "Review history contains ambiguous explicit base markers.".to_string(),
+            ));
+        };
+        if base.len() != 40 || !base.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return Err(ReviewError::Message(
+                "Review history contains an invalid explicit base marker.".to_string(),
+            ));
+        }
+        let revision = format!("{base}^{{commit}}");
+        let resolved = run_git_command(
+            "validate explicit review base",
+            &["rev-parse", "--verify", &revision],
+            &[],
+            verbose,
+        )?;
+        let resolved = String::from_utf8_lossy(&resolved.stdout).trim().to_string();
+        if resolved != *base {
+            return Err(ReviewError::Message(
+                "Review history explicit base marker does not resolve exactly.".to_string(),
+            ));
+        }
+        return Ok(Some((*base).to_string()));
+    }
+    Ok(None)
+}
+
+pub fn review_commit_message(subject: &str, base: &str) -> String {
+    format!("{subject}\n\n{REVIEW_BASE_TRAILER}{base}")
+}
+
+fn parse_merge_tree_output(stdout: &[u8]) -> Result<(Option<String>, Vec<String>), ReviewError> {
     let mut fields = stdout.split(|byte| *byte == 0);
     let tree = fields
         .next()
-        .and_then(|field| std::str::from_utf8(field).ok())
+        .map(|field| {
+            std::str::from_utf8(field).map_err(|_| {
+                ReviewError::Message("Git returned a non-UTF-8 tree object ID.".to_string())
+            })
+        })
+        .transpose()?
         .map(str::trim)
         .filter(|field| !field.is_empty())
         .map(str::to_owned);
@@ -70,9 +133,15 @@ fn parse_merge_tree_output(stdout: &[u8]) -> (Option<String>, Vec<String>) {
         if field.is_empty() {
             break;
         }
-        paths.push(String::from_utf8_lossy(field).into_owned());
+        let path = std::str::from_utf8(field).map_err(|_| {
+            ReviewError::Message(
+                "Git reported a non-UTF-8 conflict path; refusing the reconstructed tree."
+                    .to_string(),
+            )
+        })?;
+        paths.push(path.to_string());
     }
-    (tree, paths)
+    Ok((tree, paths))
 }
 
 fn reconstruction_git(
@@ -198,7 +267,7 @@ pub fn reconstruct_approval_tree_with_env(
         verbose,
         env,
     )?;
-    let (_, conflict_paths) = parse_merge_tree_output(&diagnostic.stdout);
+    let (_, conflict_paths) = parse_merge_tree_output(&diagnostic.stdout)?;
     if diagnostic.status.code() == Some(1) && conflict_paths.is_empty() {
         return Err(ReviewError::Message(
             "Approval reconstruction conflicted but Git did not identify any paths; refusing the reconstructed tree."
@@ -1222,5 +1291,21 @@ fn files_equal(left: &Path, right: &Path) -> io::Result<bool> {
         if left_count == 0 {
             return Ok(true);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_merge_tree_output;
+
+    #[test]
+    fn merge_tree_output_rejects_non_utf8_conflict_paths() {
+        let mut output = b"0123456789012345678901234567890123456789\0".to_vec();
+        output.extend_from_slice(b"unsafe-\xff.bin\0\0");
+
+        let error = parse_merge_tree_output(&output)
+            .expect_err("non-UTF-8 conflict paths must fail closed before tree adoption");
+
+        assert!(format!("{error:?}").contains("non-UTF-8 conflict path"));
     }
 }

--- a/src/review.rs
+++ b/src/review.rs
@@ -1,6 +1,5 @@
 use crate::git::{run_git_command, run_git_command_with_env, GitCommandError};
 use std::collections::{BTreeMap, BTreeSet};
-use std::ffi::OsStr;
 use std::fs;
 use std::io::{self, Read};
 use std::os::unix::fs::{symlink, MetadataExt, PermissionsExt};
@@ -18,8 +17,6 @@ pub struct ReconstructionOutcome {
     pub downgraded_paths: Vec<String>,
 }
 
-const REVIEW_BASE_TRAILER: &str = "Cresca-Review-Base: ";
-
 #[derive(Debug)]
 pub enum ReviewError {
     Git(GitCommandError),
@@ -36,7 +33,11 @@ impl From<GitCommandError> for ReviewError {
     }
 }
 
-pub fn unique_merge_base(left: &str, right: &str, verbose: bool) -> Result<String, ReviewError> {
+pub fn find_unique_merge_base(
+    left: &str,
+    right: &str,
+    verbose: bool,
+) -> Result<String, ReviewError> {
     let output = run_git_command(
         "get unique merge base",
         &["merge-base", "--all", left, right],
@@ -57,70 +58,6 @@ pub fn unique_merge_base(left: &str, right: &str, verbose: bool) -> Result<Strin
             "Multiple merge bases exist between `{left}` and `{right}`; refusing to guess approval history."
         ))),
     }
-}
-
-pub fn explicit_review_base(
-    review_head: &str,
-    current_target: &str,
-    verbose: bool,
-) -> Result<Option<String>, ReviewError> {
-    let excluded_target = format!("^{current_target}");
-    let output = run_git_command(
-        "find explicit review base",
-        &[
-            "log",
-            "--first-parent",
-            "--format=%B%x00",
-            review_head,
-            &excluded_target,
-        ],
-        &[],
-        verbose,
-    )?;
-    for message in output.stdout.split(|byte| *byte == 0) {
-        let message = std::str::from_utf8(message).map_err(|_| {
-            ReviewError::Message(
-                "Review history contains a non-UTF-8 commit message; refusing to infer its approval base."
-                    .to_string(),
-            )
-        })?;
-        let markers: Vec<_> = message
-            .lines()
-            .filter_map(|line| line.strip_prefix(REVIEW_BASE_TRAILER))
-            .collect();
-        if markers.is_empty() {
-            continue;
-        }
-        let [base] = markers.as_slice() else {
-            return Err(ReviewError::Message(
-                "Review history contains ambiguous explicit base markers.".to_string(),
-            ));
-        };
-        if base.len() != 40 || !base.bytes().all(|byte| byte.is_ascii_hexdigit()) {
-            return Err(ReviewError::Message(
-                "Review history contains an invalid explicit base marker.".to_string(),
-            ));
-        }
-        let revision = format!("{base}^{{commit}}");
-        let resolved = run_git_command(
-            "validate explicit review base",
-            &["rev-parse", "--verify", &revision],
-            &[],
-            verbose,
-        )?;
-        let resolved = String::from_utf8_lossy(&resolved.stdout).trim().to_string();
-        if resolved != *base {
-            return Err(ReviewError::Message(
-                "Review history explicit base marker does not resolve exactly.".to_string(),
-            ));
-        }
-        return Ok(Some((*base).to_string()));
-    }
-    Ok(None)
-}
-
-pub fn review_commit_message(subject: &str, base: &str) -> String {
-    format!("{subject}\n\n{REVIEW_BASE_TRAILER}{base}")
 }
 
 fn parse_merge_tree_output(stdout: &[u8]) -> Result<(Option<String>, Vec<String>), ReviewError> {
@@ -152,31 +89,25 @@ fn parse_merge_tree_output(stdout: &[u8]) -> Result<(Option<String>, Vec<String>
     Ok((tree, paths))
 }
 
-fn reconstruction_git(
+fn run_reconstruction_git_command(
     description: &str,
     args: &[&str],
     allowed_exit_codes: &[i32],
     verbose: bool,
-    env: Option<&[(&str, &OsStr)]>,
 ) -> Result<std::process::Output, GitCommandError> {
-    match env {
-        Some(env) => run_git_command_with_env(description, args, env, allowed_exit_codes, verbose),
-        None => run_git_command(description, args, allowed_exit_codes, verbose),
-    }
+    run_git_command(description, args, allowed_exit_codes, verbose)
 }
 
-fn tree_entry(
+fn read_tree_entry(
     revision: &str,
     path: &str,
     verbose: bool,
-    env: Option<&[(&str, &OsStr)]>,
 ) -> Result<Option<(String, String)>, ReviewError> {
-    let output = reconstruction_git(
+    let output = run_reconstruction_git_command(
         "inspect reconstruction tree entry",
         &["--literal-pathspecs", "ls-tree", "-z", revision, "--", path],
         &[],
         verbose,
-        env,
     )?;
     if output.stdout.is_empty() {
         return Ok(None);
@@ -201,17 +132,15 @@ fn tree_entry(
     Ok(Some((mode, oid)))
 }
 
-fn tree_entries(
+fn read_tree_entries(
     revision: &str,
     verbose: bool,
-    env: Option<&[(&str, &OsStr)]>,
 ) -> Result<BTreeMap<Vec<u8>, (String, String)>, ReviewError> {
-    let output = reconstruction_git(
+    let output = run_reconstruction_git_command(
         "inspect reconstruction tree",
         &["ls-tree", "-rz", revision],
         &[],
         verbose,
-        env,
     )?;
     let mut entries = BTreeMap::new();
     for record in output.stdout.split(|byte| *byte == 0) {
@@ -241,11 +170,10 @@ fn tree_entries(
     Ok(entries)
 }
 
-fn ambiguous_exact_rename_paths(
+fn find_ambiguous_exact_rename_paths(
     old_base: &str,
     old_review: &str,
     verbose: bool,
-    env: Option<&[(&str, &OsStr)]>,
 ) -> Result<Vec<String>, ReviewError> {
     let correspondence_key = |entry: &(String, String)| {
         let compatible_type = if entry.0 == "100644" || entry.0 == "100755" {
@@ -255,8 +183,8 @@ fn ambiguous_exact_rename_paths(
         };
         (compatible_type, entry.1.clone())
     };
-    let base = tree_entries(old_base, verbose, env)?;
-    let review = tree_entries(old_review, verbose, env)?;
+    let base = read_tree_entries(old_base, verbose)?;
+    let review = read_tree_entries(old_review, verbose)?;
     let mut removed: BTreeMap<(String, String), Vec<&[u8]>> = BTreeMap::new();
     let mut added: BTreeMap<(String, String), Vec<&[u8]>> = BTreeMap::new();
     for (path, entry) in &base {
@@ -300,17 +228,12 @@ fn ambiguous_exact_rename_paths(
         .collect()
 }
 
-fn is_binary_blob(
-    oid: &str,
-    verbose: bool,
-    env: Option<&[(&str, &OsStr)]>,
-) -> Result<bool, ReviewError> {
-    let output = reconstruction_git(
+fn is_binary_blob(oid: &str, verbose: bool) -> Result<bool, ReviewError> {
+    let output = run_reconstruction_git_command(
         "inspect conflicting blob",
         &["cat-file", "blob", oid],
         &[],
         verbose,
-        env,
     )?;
     Ok(output.stdout.contains(&0))
 }
@@ -321,24 +244,23 @@ fn text_conflict_can_keep_hunks(
     old_review: &str,
     path: &str,
     verbose: bool,
-    env: Option<&[(&str, &OsStr)]>,
 ) -> Result<bool, ReviewError> {
-    let Some(old) = tree_entry(old_base, path, verbose, env)? else {
+    let Some(old) = read_tree_entry(old_base, path, verbose)? else {
         return Ok(false);
     };
-    let Some(new) = tree_entry(new_base, path, verbose, env)? else {
+    let Some(new) = read_tree_entry(new_base, path, verbose)? else {
         return Ok(false);
     };
-    let Some(review) = tree_entry(old_review, path, verbose, env)? else {
+    let Some(review) = read_tree_entry(old_review, path, verbose)? else {
         return Ok(false);
     };
     let regular = |mode: &str| mode == "100644" || mode == "100755";
     if old.0 != new.0 || old.0 != review.0 || !regular(&old.0) {
         return Ok(false);
     }
-    Ok(!is_binary_blob(&old.1, verbose, env)?
-        && !is_binary_blob(&new.1, verbose, env)?
-        && !is_binary_blob(&review.1, verbose, env)?)
+    Ok(!is_binary_blob(&old.1, verbose)?
+        && !is_binary_blob(&new.1, verbose)?
+        && !is_binary_blob(&review.1, verbose)?)
 }
 
 pub fn reconstruct_approval_tree(
@@ -347,17 +269,7 @@ pub fn reconstruct_approval_tree(
     old_review: &str,
     verbose: bool,
 ) -> Result<ReconstructionOutcome, ReviewError> {
-    reconstruct_approval_tree_with_env(old_base, new_base, old_review, verbose, None)
-}
-
-pub fn reconstruct_approval_tree_with_env(
-    old_base: &str,
-    new_base: &str,
-    old_review: &str,
-    verbose: bool,
-    env: Option<&[(&str, &OsStr)]>,
-) -> Result<ReconstructionOutcome, ReviewError> {
-    let diagnostic = reconstruction_git(
+    let diagnostic = run_reconstruction_git_command(
         "identify approval reconstruction conflicts",
         &[
             "merge-tree",
@@ -372,7 +284,6 @@ pub fn reconstruct_approval_tree_with_env(
         ],
         &[1],
         verbose,
-        env,
     )?;
     let (_, conflict_paths) = parse_merge_tree_output(&diagnostic.stdout)?;
     if diagnostic.status.code() == Some(1) && conflict_paths.is_empty() {
@@ -382,7 +293,7 @@ pub fn reconstruct_approval_tree_with_env(
         ));
     }
 
-    let merged = reconstruction_git(
+    let merged = run_reconstruction_git_command(
         "reconstruct approved tree",
         &[
             "merge-tree",
@@ -396,7 +307,6 @@ pub fn reconstruct_approval_tree_with_env(
         ],
         &[1],
         verbose,
-        env,
     )?;
     let tree_oid = String::from_utf8_lossy(&merged.stdout)
         .lines()
@@ -410,13 +320,13 @@ pub fn reconstruct_approval_tree_with_env(
         ));
     }
 
-    let mut downgraded = ambiguous_exact_rename_paths(old_base, new_base, verbose, env)?;
-    downgraded.extend(ambiguous_exact_rename_paths(
-        old_base, old_review, verbose, env,
+    let mut downgraded = find_ambiguous_exact_rename_paths(old_base, new_base, verbose)?;
+    downgraded.extend(find_ambiguous_exact_rename_paths(
+        old_base, old_review, verbose,
     )?);
     for path in &conflict_paths {
         if merged.status.code() == Some(1)
-            || !text_conflict_can_keep_hunks(old_base, new_base, old_review, path, verbose, env)?
+            || !text_conflict_can_keep_hunks(old_base, new_base, old_review, path, verbose)?
         {
             downgraded.push(path.clone());
         }
@@ -434,9 +344,7 @@ pub fn reconstruct_approval_tree_with_env(
         ReviewError::Message(format!("failed to create scratch index: {error}"))
     })?;
     let index = scratch.path().join("index");
-    let mut scratch_env: Vec<(&str, &OsStr)> = env.unwrap_or_default().to_vec();
-    scratch_env.retain(|(key, _)| *key != "GIT_INDEX_FILE");
-    scratch_env.push(("GIT_INDEX_FILE", index.as_os_str()));
+    let scratch_env = [("GIT_INDEX_FILE", index.as_os_str())];
     run_git_command_with_env(
         "load reconstructed tree into scratch index",
         &["read-tree", &tree_oid],

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -809,6 +809,49 @@ fn test_review_ref_update_failure_rolls_back_exact_repository_state() {
 }
 
 #[test]
+fn test_rereview_merge_tree_failure_preserves_previous_review_exactly() {
+    let repo = TempGitRepo::new();
+    repo.create_branch("develop");
+    repo.write_file("approved.txt", "approved\n");
+    repo.git(&["add", "approved.txt"]);
+    repo.commit("Add approved content");
+    repo.git(&["push", "-u", "origin", "develop"]);
+    repo.switch_branch("main");
+    assert!(repo
+        .run_cresca(&["review", "main", "develop"])
+        .status
+        .success());
+    repo.git(&["add", "approved.txt"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+
+    repo.switch_branch("main");
+    repo.write_file("target.txt", "target baseline\n");
+    repo.git(&["add", "target.txt"]);
+    repo.commit("Advance target");
+    repo.git(&["push", "origin", "main"]);
+    repo.git(&["checkout", "-B", "develop", "main"]);
+    repo.write_file("approved.txt", "approved\n");
+    repo.git(&["add", "approved.txt"]);
+    repo.commit("Rebase approved content");
+    repo.git(&["push", "--force", "origin", "develop"]);
+    repo.switch_branch("review-main-develop");
+    let before = repo.snapshot();
+    let wrapper = install_git_wrapper(
+        &repo,
+        "#!/bin/sh\ncase \" $* \" in\n  *' merge-tree '*' -Xours '*)\n    printf 'injected merge-tree stdout\\n'\n    printf 'injected merge-tree failure\\n' >&2\n    exit 63\n    ;;\nesac\nexec \"$CRESCA_REAL_GIT\" \"$@\"\n",
+    );
+
+    let output = run_cresca_with_git_wrapper(&repo, &wrapper, &["review", "main", "develop"]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("reconstruct approved tree"), "{stderr}");
+    assert!(stderr.contains("injected merge-tree stdout"), "{stderr}");
+    assert!(stderr.contains("injected merge-tree failure"), "{stderr}");
+    assert_eq!(repo.snapshot(), before);
+    assert!(repo.run_cresca(&["status"]).status.success());
+}
+
+#[test]
 fn test_post_transaction_status_failure_rolls_back_new_review_exactly() {
     let (repo, _) = setup_linear_range();
     let before = repo.snapshot();
@@ -1115,7 +1158,7 @@ fn test_review_records_source_tip_as_full_scope_end_without_stop_at() {
     );
     assert_eq!(
         repo.review_scope_values("review-main-develop"),
-        vec![format!("1:{}", range.d)]
+        vec![format!("2:{}:{}", range.base, range.d)]
     );
 }
 
@@ -1130,7 +1173,7 @@ fn test_review_records_stop_at_as_full_scope_end() {
     );
     assert_eq!(
         repo.review_scope_values("review-main-develop"),
-        vec![format!("1:{}", range.c)]
+        vec![format!("2:{}:{}", range.base, range.c)]
     );
 }
 
@@ -1153,7 +1196,7 @@ fn test_review_scope_end_is_independent_of_skip_to() {
     );
     assert_eq!(
         repo.review_scope_values("review-main-develop"),
-        vec![format!("1:{}", range.c)]
+        vec![format!("2:{}:{}", range.base, range.c)]
     );
 }
 
@@ -1174,7 +1217,7 @@ fn test_successful_rereview_replaces_scope_end() {
     );
     assert_eq!(
         repo.review_scope_values("review-main-develop"),
-        vec![format!("1:{}", range.d)]
+        vec![format!("2:{}:{}", range.base, range.d)]
     );
 }
 
@@ -1188,12 +1231,59 @@ fn test_failed_rereview_preserves_previous_scope_end() {
     repo.git(&["add", "-A"]);
     assert!(repo.run_cresca(&["approve"]).status.success());
     let before = repo.review_scope_values("review-main-develop");
-    assert_eq!(before, vec![format!("1:{}", range.c)]);
+    assert_eq!(before, vec![format!("2:{}:{}", range.base, range.c)]);
     let output = repo.run_cresca(&["review", "main", "develop", "--stop-at", "does-not-exist"]);
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("does-not-exist") && stderr.contains("is not in the range"));
     assert_eq!(repo.review_scope_values("review-main-develop"), before);
+}
+
+#[test]
+fn test_rereview_migrates_version_one_scope_to_explicit_base() {
+    let (repo, range) = setup_linear_range();
+    assert!(repo
+        .run_cresca(&["review", "main", "develop", "--stop-at", &range.c[..8]])
+        .status
+        .success());
+    repo.git(&["add", "-A"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+    repo.git(&[
+        "config",
+        "--local",
+        "branch.review-main-develop.cresca-scope",
+        &format!("1:{}", range.c),
+    ]);
+
+    let output = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        repo.review_scope_values("review-main-develop"),
+        vec![format!("2:{}:{}", range.base, range.d)]
+    );
+}
+
+#[test]
+fn test_existing_identity_review_without_scope_migrates_only_from_unique_base() {
+    let repo = setup_identity_only_review_branch();
+    let old_head = repo.rev_parse("HEAD");
+
+    let output = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let endpoint = repo.rev_parse("origin/develop");
+    assert_eq!(repo.rev_parse("HEAD^"), old_head);
+    assert_eq!(
+        repo.review_scope_values("review-main-develop"),
+        vec![format!("2:{old_head}:{endpoint}")]
+    );
 }
 
 fn assert_review_matches(
@@ -1477,7 +1567,11 @@ fn test_approve_with_no_staged_changes_approves_nothing() {
         String::from_utf8_lossy(&rereview_output.stdout),
         String::from_utf8_lossy(&rereview_output.stderr)
     );
-    assert_eq!(repo.rev_parse("HEAD"), head_before);
+    assert_eq!(repo.rev_parse("HEAD^"), head_before);
+    assert_eq!(
+        repo.rev_parse("HEAD^{tree}"),
+        repo.rev_parse(&format!("{head_before}^{{tree}}"))
+    );
     assert_eq!(repo.worktree_diff(), expected_source_diff);
 }
 
@@ -1568,6 +1662,64 @@ fn test_review_with_uncommitted_changes() {
     );
 }
 
+fn setup_multiple_merge_bases() -> TempGitRepo {
+    let repo = TempGitRepo::new();
+    let root = repo.rev_parse("HEAD");
+    repo.create_branch("left-base");
+    repo.write_file("left.txt", "left base\n");
+    repo.git(&["add", "left.txt"]);
+    repo.commit("Create left merge base");
+    let left = repo.rev_parse("HEAD");
+    repo.git(&["checkout", "-b", "right-base", &root]);
+    repo.write_file("right.txt", "right base\n");
+    repo.git(&["add", "right.txt"]);
+    repo.commit("Create right merge base");
+    let right = repo.rev_parse("HEAD");
+    let left_tree = repo.rev_parse(&format!("{left}^{{tree}}"));
+    let right_tree = repo.rev_parse(&format!("{right}^{{tree}}"));
+    let target = repo.git_stdout(&[
+        "commit-tree",
+        &left_tree,
+        "-p",
+        &left,
+        "-p",
+        &right,
+        "-m",
+        "target merge",
+    ]);
+    let source = repo.git_stdout(&[
+        "commit-tree",
+        &right_tree,
+        "-p",
+        &right,
+        "-p",
+        &left,
+        "-m",
+        "source merge",
+    ]);
+    repo.git(&["update-ref", "refs/heads/main", &target]);
+    repo.git(&["update-ref", "refs/heads/develop", &source]);
+    repo.git(&["push", "--force", "origin", "main", "develop"]);
+    repo.git(&["checkout", "--force", "main"]);
+    repo
+}
+
+#[test]
+fn test_review_fails_closed_for_multiple_merge_bases_without_mutation() {
+    let repo = setup_multiple_merge_bases();
+    let before = repo.snapshot();
+
+    let output = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("Multiple merge bases"),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(repo.snapshot(), before);
+    assert!(!repo.ref_exists("refs/heads/review-main-develop"));
+}
+
 /// Test that running review twice updates the review branch correctly.
 #[test]
 fn test_review_updates_existing_branch() {
@@ -1612,6 +1764,267 @@ fn test_review_updates_existing_branch() {
         status_str.contains("file2.txt"),
         "file2.txt should appear as new unreviewed change"
     );
+}
+
+#[test]
+fn test_rereview_reconstructs_approved_tree_after_target_update_and_source_rebase() {
+    let repo = TempGitRepo::new();
+
+    repo.create_branch("develop");
+    repo.write_file("approved.txt", "approved source content\n");
+    repo.git(&["add", "approved.txt"]);
+    repo.commit("Add source change");
+    repo.git(&["push", "-u", "origin", "develop"]);
+    repo.switch_branch("main");
+
+    let first = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        first.status.success(),
+        "{}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+    repo.git(&["add", "approved.txt"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+    let old_review_head = repo.rev_parse("HEAD");
+
+    repo.switch_branch("main");
+    repo.write_file("target-only.txt", "new target baseline\n");
+    repo.git(&["add", "target-only.txt"]);
+    repo.commit("Advance target");
+    repo.git(&["push", "origin", "main"]);
+    let new_base = repo.rev_parse("HEAD");
+
+    repo.switch_branch("develop");
+    repo.git(&["rebase", "main"]);
+    repo.git(&["push", "--force", "origin", "develop"]);
+    let endpoint = repo.rev_parse("HEAD");
+    repo.switch_branch("review-main-develop");
+
+    let rereview = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        rereview.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&rereview.stdout),
+        String::from_utf8_lossy(&rereview.stderr)
+    );
+    assert_eq!(repo.rev_parse("HEAD^"), old_review_head);
+    assert_eq!(
+        repo.rev_parse("HEAD^{tree}"),
+        repo.rev_parse(&format!("{endpoint}^{{tree}}"))
+    );
+    assert!(repo.cached_diff().is_empty());
+    assert!(repo.worktree_diff().is_empty());
+    assert_eq!(
+        repo.review_scope_values("review-main-develop"),
+        vec![format!("2:{new_base}:{endpoint}")]
+    );
+}
+
+#[test]
+fn test_rereview_downgrades_only_conflicting_text_hunks_to_new_base() {
+    let repo = TempGitRepo::new();
+    repo.write_file(
+        "lines.txt",
+        "base conflict\nkeep 1\nkeep 2\nkeep 3\nkeep 4\nbase approved\nbase untouched\n",
+    );
+    repo.git(&["add", "lines.txt"]);
+    repo.commit("Add line reconstruction fixture");
+    repo.git(&["push", "origin", "main"]);
+
+    repo.create_branch("develop");
+    repo.write_file(
+        "lines.txt",
+        "old source conflict\nkeep 1\nkeep 2\nkeep 3\nkeep 4\napproved line\nbase untouched\n",
+    );
+    repo.git(&["add", "lines.txt"]);
+    repo.commit("Change source lines");
+    repo.git(&["push", "-u", "origin", "develop"]);
+    repo.switch_branch("main");
+    assert!(repo
+        .run_cresca(&["review", "main", "develop"])
+        .status
+        .success());
+    repo.git(&["add", "lines.txt"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+
+    repo.switch_branch("main");
+    repo.write_file(
+        "lines.txt",
+        "target conflict\nkeep 1\nkeep 2\nkeep 3\nkeep 4\nbase approved\nbase untouched\n",
+    );
+    repo.git(&["add", "lines.txt"]);
+    repo.commit("Change target conflict line");
+    repo.git(&["push", "origin", "main"]);
+    repo.git(&["checkout", "-B", "develop", "main"]);
+    repo.write_file(
+        "lines.txt",
+        "new source conflict\nkeep 1\nkeep 2\nkeep 3\nkeep 4\napproved line\nbase untouched\n",
+    );
+    repo.git(&["add", "lines.txt"]);
+    repo.commit("Reapply source on new target");
+    repo.git(&["push", "--force", "origin", "develop"]);
+    repo.switch_branch("review-main-develop");
+
+    let output = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        repo.git_stdout(&["show", "HEAD:lines.txt"]),
+        "target conflict\nkeep 1\nkeep 2\nkeep 3\nkeep 4\napproved line\nbase untouched"
+    );
+    assert_eq!(
+        repo.read_file("lines.txt"),
+        "new source conflict\nkeep 1\nkeep 2\nkeep 3\nkeep 4\napproved line\nbase untouched\n"
+    );
+    assert!(repo
+        .git_stdout(&["diff", "--name-only"])
+        .contains("lines.txt"));
+}
+
+#[test]
+fn test_rereview_downgrades_binary_conflict_to_new_base_entry() {
+    let repo = TempGitRepo::new();
+    std::fs::write(repo.path().join("binary.bin"), b"base\0value")
+        .expect("binary base should be writable");
+    repo.git(&["add", "binary.bin"]);
+    repo.commit("Add binary fixture");
+    repo.git(&["push", "origin", "main"]);
+
+    repo.create_branch("develop");
+    std::fs::write(repo.path().join("binary.bin"), b"old-source\0value")
+        .expect("binary source should be writable");
+    repo.git(&["add", "binary.bin"]);
+    repo.commit("Change source binary");
+    repo.git(&["push", "-u", "origin", "develop"]);
+    repo.switch_branch("main");
+    assert!(repo
+        .run_cresca(&["review", "main", "develop"])
+        .status
+        .success());
+    repo.git(&["add", "binary.bin"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+
+    repo.switch_branch("main");
+    std::fs::write(repo.path().join("binary.bin"), b"target\0value")
+        .expect("binary target should be writable");
+    repo.git(&["add", "binary.bin"]);
+    repo.commit("Change target binary");
+    repo.git(&["push", "origin", "main"]);
+    repo.git(&["checkout", "-B", "develop", "main"]);
+    std::fs::write(repo.path().join("binary.bin"), b"new-source\0value")
+        .expect("binary endpoint should be writable");
+    repo.git(&["add", "binary.bin"]);
+    repo.commit("Reapply binary source");
+    repo.git(&["push", "--force", "origin", "develop"]);
+    repo.switch_branch("review-main-develop");
+
+    let output = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        repo.git(&["show", "HEAD:binary.bin"]).stdout,
+        b"target\0value"
+    );
+    assert_eq!(
+        std::fs::read(repo.path().join("binary.bin")).expect("binary worktree should be readable"),
+        b"new-source\0value"
+    );
+}
+
+#[test]
+fn test_rereview_handles_mode_symlink_modify_delete_and_rename_delete_safely() {
+    let repo = TempGitRepo::new();
+    repo.write_file("mode.sh", "base script\n");
+    repo.write_file("modify-delete.txt", "base file\n");
+    repo.write_file("rename-old.txt", "rename content\n");
+    std::os::unix::fs::symlink("base-target", repo.path().join("link"))
+        .expect("base symlink should be created");
+    repo.git(&["add", "."]);
+    repo.commit("Add tree safety fixtures");
+    repo.git(&["push", "origin", "main"]);
+
+    repo.create_branch("develop");
+    let mut mode = std::fs::metadata(repo.path().join("mode.sh"))
+        .expect("mode fixture should exist")
+        .permissions();
+    mode.set_mode(0o755);
+    std::fs::set_permissions(repo.path().join("mode.sh"), mode)
+        .expect("mode fixture should become executable");
+    repo.write_file("modify-delete.txt", "approved modification\n");
+    repo.git(&["mv", "rename-old.txt", "rename-approved.txt"]);
+    std::fs::remove_file(repo.path().join("link")).expect("old symlink should be removable");
+    std::os::unix::fs::symlink("approved-target", repo.path().join("link"))
+        .expect("approved symlink should be created");
+    repo.git(&["add", "."]);
+    repo.commit("Approve tree-kind changes");
+    repo.git(&["push", "-u", "origin", "develop"]);
+    repo.switch_branch("main");
+    assert!(repo
+        .run_cresca(&["review", "main", "develop"])
+        .status
+        .success());
+    repo.git(&["add", "-A"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+
+    repo.switch_branch("main");
+    repo.write_file("mode.sh", "target script\n");
+    repo.git(&["rm", "modify-delete.txt", "rename-old.txt"]);
+    std::fs::remove_file(repo.path().join("link")).expect("base symlink should be removable");
+    std::os::unix::fs::symlink("target-link", repo.path().join("link"))
+        .expect("target symlink should be created");
+    repo.git(&["add", "."]);
+    repo.commit("Advance target tree kinds");
+    repo.git(&["push", "origin", "main"]);
+    repo.git(&["checkout", "-B", "develop", "main"]);
+    let mut mode = std::fs::metadata(repo.path().join("mode.sh"))
+        .expect("rebased mode fixture should exist")
+        .permissions();
+    mode.set_mode(0o755);
+    std::fs::set_permissions(repo.path().join("mode.sh"), mode)
+        .expect("rebased mode fixture should become executable");
+    repo.write_file("modify-delete.txt", "new source recreation\n");
+    repo.write_file("rename-approved.txt", "rename content\n");
+    std::fs::remove_file(repo.path().join("link")).expect("target symlink should be removable");
+    std::os::unix::fs::symlink("new-source-link", repo.path().join("link"))
+        .expect("new source symlink should be created");
+    repo.git(&["add", "."]);
+    repo.commit("Reapply tree-kind source changes");
+    repo.git(&["push", "--force", "origin", "develop"]);
+    repo.switch_branch("review-main-develop");
+
+    let output = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(repo.git_stdout(&["show", "HEAD:mode.sh"]), "target script");
+    assert!(repo
+        .git_stdout(&["ls-tree", "HEAD", "mode.sh"])
+        .starts_with("100755 "));
+    assert_eq!(repo.git_stdout(&["show", "HEAD:link"]), "target-link");
+    assert!(repo
+        .git_maybe(&["cat-file", "-e", "HEAD:modify-delete.txt"])
+        .status
+        .code()
+        .is_some_and(|code| code != 0));
+    assert!(repo
+        .git_maybe(&["cat-file", "-e", "HEAD:rename-approved.txt"])
+        .status
+        .code()
+        .is_some_and(|code| code != 0));
+    assert_eq!(
+        std::fs::read_link(repo.path().join("link")).unwrap(),
+        PathBuf::from("new-source-link")
+    );
+    assert!(repo.path().join("modify-delete.txt").exists());
+    assert!(repo.path().join("rename-approved.txt").exists());
 }
 
 /// Test that `cresca review --skip-to` auto-approves earlier commits.
@@ -2623,14 +3036,7 @@ fn test_review_leaves_legacy_branch_untouched_and_creates_metadata_backed_branch
 
     assert!(repo.run_cresca(&["approve"]).status.success());
     repo.switch_branch("main");
-    let heads_before = repo
-        .git(&[
-            "for-each-ref",
-            "--sort=refname",
-            "--format=%(refname) %(objectname)",
-            "refs/heads/",
-        ])
-        .stdout;
+    let previous_review = repo.rev_parse(&format!("refs/heads/{metadata_branch}"));
 
     let second = repo.run_cresca(&["review", "main", "develop"]);
     assert!(
@@ -2640,16 +3046,8 @@ fn test_review_leaves_legacy_branch_untouched_and_creates_metadata_backed_branch
         String::from_utf8_lossy(&second.stderr)
     );
     assert_eq!(repo.current_branch(), metadata_branch);
-    assert_eq!(
-        repo.git(&[
-            "for-each-ref",
-            "--sort=refname",
-            "--format=%(refname) %(objectname)",
-            "refs/heads/",
-        ])
-        .stdout,
-        heads_before
-    );
+    assert_eq!(repo.rev_parse("HEAD^"), previous_review);
+    assert_eq!(repo.rev_parse("refs/heads/review-main-develop"), legacy_oid);
 }
 
 #[test]
@@ -2805,14 +3203,14 @@ fn test_status_rejects_duplicate_scope_values_but_all_still_works() {
 #[test]
 fn test_status_rejects_unsupported_scope_version_but_all_still_works() {
     let repo = setup_identity_only_review_branch();
-    let value = format!("2:{}", repo.rev_parse("HEAD"));
+    let value = format!("3:{}", repo.rev_parse("HEAD"));
     repo.git(&[
         "config",
         "--local",
         "branch.review-main-develop.cresca-scope",
         &value,
     ]);
-    assert_scope_error_and_all_available(&repo, "range metadata version '2' is unsupported");
+    assert_scope_error_and_all_available(&repo, "range metadata version '3' is unsupported");
 }
 
 #[test]
@@ -2889,6 +3287,124 @@ fn test_status_keeps_unbounded_review_tip_fixed_until_next_review() {
             "    - e.txt\n",
         )
     );
+}
+
+#[test]
+fn test_status_all_temporarily_reconstructs_after_target_and_source_rebase_without_mutation() {
+    let repo = TempGitRepo::new();
+    repo.create_branch("develop");
+    repo.write_file("approved.txt", "approved content\n");
+    repo.git(&["add", "approved.txt"]);
+    repo.commit("Add approved source content");
+    repo.git(&["push", "-u", "origin", "develop"]);
+    repo.switch_branch("main");
+    assert!(repo
+        .run_cresca(&["review", "main", "develop"])
+        .status
+        .success());
+    repo.git(&["add", "approved.txt"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+
+    repo.switch_branch("main");
+    repo.write_file("target-only.txt", "new target baseline\n");
+    repo.git(&["add", "target-only.txt"]);
+    repo.commit("Advance target baseline");
+    repo.git(&["push", "origin", "main"]);
+    repo.git(&["checkout", "-B", "develop", "main"]);
+    repo.write_file("approved.txt", "approved content\n");
+    repo.write_file("later.txt", "new unreviewed content\n");
+    repo.git(&["add", "."]);
+    repo.commit("Rebase approved content and add later change");
+    repo.git(&["push", "--force", "origin", "develop"]);
+    repo.switch_branch("review-main-develop");
+
+    let before = repo.snapshot();
+    let objects_before = repo.git_stdout(&["count-objects", "-v"]);
+    let all = run_status_stdout(&repo, &["status", "--all"]);
+    assert!(
+        all.contains("1 file(s), +1 insertion(s), -0 deletion(s)"),
+        "{all}"
+    );
+    assert!(all.contains("    - later.txt\n"), "{all}");
+    assert!(!all.contains("target-only.txt"), "{all}");
+    assert!(!all.contains("approved.txt"), "{all}");
+    assert_eq!(repo.snapshot(), before);
+    assert_eq!(repo.git_stdout(&["count-objects", "-v"]), objects_before);
+}
+
+#[test]
+fn test_status_all_fails_closed_for_unrelated_source_history_without_mutation() {
+    let repo = TempGitRepo::new();
+    repo.git(&["checkout", "--orphan", "develop"]);
+    repo.git(&["rm", "-rf", "."]);
+    repo.write_file("unrelated.txt", "unrelated source\n");
+    repo.git(&["add", "unrelated.txt"]);
+    repo.commit("Create unrelated source history");
+    repo.git(&["push", "-u", "origin", "develop"]);
+    repo.switch_branch("main");
+    repo.create_branch("review-main-develop");
+    repo.git(&[
+        "config",
+        "--local",
+        "branch.review-main-develop.cresca-version",
+        "1",
+    ]);
+    repo.git(&[
+        "config",
+        "--local",
+        "branch.review-main-develop.cresca-target",
+        "main",
+    ]);
+    repo.git(&[
+        "config",
+        "--local",
+        "branch.review-main-develop.cresca-source",
+        "develop",
+    ]);
+    let before = repo.snapshot();
+
+    let output = repo.run_cresca(&["status", "--all"]);
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("No unique safe merge base"),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(repo.snapshot(), before);
+}
+
+#[test]
+fn test_status_all_fails_closed_for_multiple_merge_bases_without_mutation() {
+    let repo = setup_multiple_merge_bases();
+    repo.create_branch("review-main-develop");
+    repo.git(&[
+        "config",
+        "--local",
+        "branch.review-main-develop.cresca-version",
+        "1",
+    ]);
+    repo.git(&[
+        "config",
+        "--local",
+        "branch.review-main-develop.cresca-target",
+        "main",
+    ]);
+    repo.git(&[
+        "config",
+        "--local",
+        "branch.review-main-develop.cresca-source",
+        "develop",
+    ]);
+    let before = repo.snapshot();
+
+    let output = repo.run_cresca(&["status", "--all"]);
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("Multiple merge bases"),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(repo.snapshot(), before);
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -30,6 +30,21 @@ fn real_git_path() -> String {
         .to_string()
 }
 
+fn set_gitlink(repo: &TempGitRepo, path: &str, oid: &str) {
+    repo.git(&["update-index", "--add", "--cacheinfo", "160000", oid, path]);
+}
+
+fn remove_index_entry(repo: &TempGitRepo, path: &str) {
+    repo.git(&["update-index", "--force-remove", path]);
+}
+
+fn materialize_uninitialized_gitlinks(repo: &TempGitRepo, paths: &[&str]) {
+    for path in paths {
+        std::fs::create_dir_all(repo.path().join(path))
+            .expect("uninitialized Gitlink directory should be creatable");
+    }
+}
+
 fn run_cresca_with_git_wrapper(
     repo: &TempGitRepo,
     wrapper: &tempfile::TempDir,
@@ -1917,6 +1932,17 @@ fn test_rereview_reconstructs_approved_tree_after_target_update_and_source_rebas
     );
     assert_eq!(repo.rev_parse("HEAD^"), old_review_head);
     assert_eq!(
+        repo.git_stdout(&["rev-list", "--parents", "-n", "1", "HEAD"])
+            .split_whitespace()
+            .count(),
+        2,
+        "a reconstructed review commit must have exactly one parent"
+    );
+    assert_eq!(
+        repo.git_stdout(&["show", "-s", "--format=%B", "HEAD"]),
+        "Reconstruct approved changes"
+    );
+    assert_eq!(
         repo.rev_parse("HEAD^{tree}"),
         repo.rev_parse(&format!("{endpoint}^{{tree}}"))
     );
@@ -2418,6 +2444,198 @@ fn test_rereview_downgrades_target_side_ambiguous_identical_rename() {
         "unrelated approved content"
     );
     assert_eq!(repo.worktree_diff(), repo.diff("HEAD", &endpoint));
+}
+
+#[test]
+fn test_rereview_does_not_transfer_approval_through_ambiguous_identical_gitlink_rename() {
+    let repo = TempGitRepo::new();
+    let original_gitlink = repo.rev_parse("HEAD");
+    repo.git(&[
+        "commit",
+        "--allow-empty",
+        "-m",
+        "Create alternate Gitlink object",
+    ]);
+    let alternate_gitlink = repo.rev_parse("HEAD");
+    set_gitlink(&repo, "review-left", &original_gitlink);
+    set_gitlink(&repo, "review-right", &original_gitlink);
+    repo.commit("Add identical review-side Gitlink candidates");
+    let old_base = repo.rev_parse("HEAD");
+    repo.git(&["push", "origin", "main"]);
+
+    repo.create_branch("develop");
+    remove_index_entry(&repo, "review-left");
+    remove_index_entry(&repo, "review-right");
+    set_gitlink(&repo, "review-renamed", &original_gitlink);
+    repo.write_file("unrelated-approved.txt", "unrelated approved content\n");
+    repo.git(&["add", "unrelated-approved.txt"]);
+    repo.commit("Approve ambiguous review-side Gitlink rename");
+    repo.git(&["push", "-u", "origin", "develop"]);
+    repo.switch_branch("main");
+    materialize_uninitialized_gitlinks(&repo, &["review-left", "review-right"]);
+    let first_review = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        first_review.status.success(),
+        "repository status after initial review failure: {}\nstdout: {}\nstderr: {}",
+        repo.git_stdout(&["status", "--porcelain"]),
+        String::from_utf8_lossy(&first_review.stdout),
+        String::from_utf8_lossy(&first_review.stderr)
+    );
+    remove_index_entry(&repo, "review-left");
+    remove_index_entry(&repo, "review-right");
+    set_gitlink(&repo, "review-renamed", &original_gitlink);
+    repo.git(&["add", "unrelated-approved.txt"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+
+    repo.switch_branch("main");
+    set_gitlink(&repo, "review-left", &alternate_gitlink);
+    set_gitlink(&repo, "review-right", &old_base);
+    repo.commit("Change review-side target Gitlinks");
+    repo.git(&["push", "origin", "main"]);
+    let new_base = repo.rev_parse("HEAD");
+
+    repo.git(&["checkout", "-b", "expected-review-gitlink", &new_base]);
+    repo.write_file("unrelated-approved.txt", "unrelated approved content\n");
+    repo.git(&["add", "unrelated-approved.txt"]);
+    repo.commit("Build expected review-side Gitlink tree");
+    let expected_tree = repo.rev_parse("HEAD^{tree}");
+
+    repo.git(&["checkout", "-B", "develop", &new_base]);
+    remove_index_entry(&repo, "review-left");
+    remove_index_entry(&repo, "review-right");
+    set_gitlink(&repo, "review-renamed", &original_gitlink);
+    repo.write_file("unrelated-approved.txt", "unrelated approved content\n");
+    repo.write_file("later.txt", "unreviewed endpoint content\n");
+    repo.git(&["add", "unrelated-approved.txt", "later.txt"]);
+    repo.commit("Reapply review-side Gitlink rename");
+    let endpoint = repo.rev_parse("HEAD");
+    repo.git(&["push", "--force", "origin", "develop"]);
+    repo.switch_branch("review-main-develop");
+    materialize_uninitialized_gitlinks(&repo, &["review-renamed"]);
+
+    let output = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        output.status.success(),
+        "repository status after rereview failure: {}\nstdout: {}\nstderr: {}",
+        repo.git_stdout(&["status", "--porcelain"]),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(repo.rev_parse("HEAD^{tree}"), expected_tree);
+    assert_eq!(
+        repo.git_stdout(&["ls-tree", "HEAD", "review-left"]),
+        format!("160000 commit {alternate_gitlink}\treview-left")
+    );
+    assert_eq!(
+        repo.git_stdout(&["ls-tree", "HEAD", "review-right"]),
+        format!("160000 commit {old_base}\treview-right")
+    );
+    assert!(repo
+        .git_stdout(&["ls-tree", "HEAD", "review-renamed"])
+        .is_empty());
+    assert_eq!(
+        repo.git_stdout(&["show", "HEAD:unrelated-approved.txt"]),
+        "unrelated approved content"
+    );
+    assert!(repo.cached_diff().is_empty());
+    assert_eq!(
+        repo.git_stdout(&["status", "--porcelain"]),
+        "?? later.txt",
+        "scratch-index reconstruction must not leak into the real index or worktree"
+    );
+    assert_eq!(repo.rev_parse("origin/develop"), endpoint);
+}
+
+#[test]
+fn test_rereview_preserves_target_through_ambiguous_identical_gitlink_rename() {
+    let repo = TempGitRepo::new();
+    let original_gitlink = repo.rev_parse("HEAD");
+    repo.git(&[
+        "commit",
+        "--allow-empty",
+        "-m",
+        "Create modified Gitlink object",
+    ]);
+    let approved_gitlink = repo.rev_parse("HEAD");
+    set_gitlink(&repo, "target-left", &original_gitlink);
+    set_gitlink(&repo, "target-right", &original_gitlink);
+    repo.commit("Add identical target-side Gitlink candidates");
+    repo.git(&["push", "origin", "main"]);
+
+    repo.create_branch("develop");
+    set_gitlink(&repo, "target-left", &approved_gitlink);
+    repo.write_file("unrelated-approved.txt", "unrelated approved content\n");
+    repo.git(&["add", "unrelated-approved.txt"]);
+    repo.commit("Approve target-side Gitlink candidate");
+    repo.git(&["push", "-u", "origin", "develop"]);
+    repo.switch_branch("main");
+    materialize_uninitialized_gitlinks(&repo, &["target-left", "target-right"]);
+    let first_review = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        first_review.status.success(),
+        "repository status after initial review failure: {}\nstdout: {}\nstderr: {}",
+        repo.git_stdout(&["status", "--porcelain"]),
+        String::from_utf8_lossy(&first_review.stdout),
+        String::from_utf8_lossy(&first_review.stderr)
+    );
+    set_gitlink(&repo, "target-left", &approved_gitlink);
+    repo.git(&["add", "unrelated-approved.txt"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+
+    repo.switch_branch("main");
+    remove_index_entry(&repo, "target-left");
+    remove_index_entry(&repo, "target-right");
+    set_gitlink(&repo, "target-renamed", &original_gitlink);
+    repo.commit("Ambiguously rename identical target Gitlinks");
+    repo.git(&["push", "origin", "main"]);
+    let new_base = repo.rev_parse("HEAD");
+
+    repo.git(&["checkout", "-b", "expected-target-gitlink", &new_base]);
+    repo.write_file("unrelated-approved.txt", "unrelated approved content\n");
+    repo.git(&["add", "unrelated-approved.txt"]);
+    repo.commit("Build expected target-side Gitlink tree");
+    let expected_tree = repo.rev_parse("HEAD^{tree}");
+
+    repo.git(&["checkout", "-B", "develop", &new_base]);
+    set_gitlink(&repo, "target-renamed", &approved_gitlink);
+    repo.write_file("unrelated-approved.txt", "unrelated approved content\n");
+    repo.write_file("later.txt", "unreviewed endpoint content\n");
+    repo.git(&["add", "unrelated-approved.txt", "later.txt"]);
+    repo.commit("Reapply target-side Gitlink modification");
+    let endpoint = repo.rev_parse("HEAD");
+    repo.git(&["push", "--force", "origin", "develop"]);
+    repo.switch_branch("review-main-develop");
+    materialize_uninitialized_gitlinks(&repo, &["target-left", "target-right"]);
+
+    let output = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(repo.rev_parse("HEAD^{tree}"), expected_tree);
+    assert_eq!(
+        repo.git_stdout(&["ls-tree", "HEAD", "target-renamed"]),
+        format!("160000 commit {original_gitlink}\ttarget-renamed")
+    );
+    assert!(repo
+        .git_stdout(&["ls-tree", "HEAD", "target-left"])
+        .is_empty());
+    assert!(repo
+        .git_stdout(&["ls-tree", "HEAD", "target-right"])
+        .is_empty());
+    assert_eq!(
+        repo.git_stdout(&["show", "HEAD:unrelated-approved.txt"]),
+        "unrelated approved content"
+    );
+    assert!(repo.cached_diff().is_empty());
+    assert_eq!(
+        repo.git_stdout(&["status", "--porcelain"]),
+        "?? later.txt",
+        "scratch-index reconstruction must not leak into the real index or worktree"
+    );
+    assert_eq!(repo.rev_parse("origin/develop"), endpoint);
 }
 
 #[test]
@@ -3774,7 +3992,18 @@ fn assert_scope_error_preserves_state(repo: &TempGitRepo, expected_error: &str) 
         stderr.contains(expected_error),
         "unexpected diagnostic: {stderr}"
     );
-    assert!(stderr.contains("cresca review main develop"));
+    assert!(
+        stderr.contains("review branch must be recreated"),
+        "unexpected remediation: {stderr}"
+    );
+    assert!(
+        stderr.contains("Switch away from it, delete it, then run `cresca review main develop`"),
+        "invalid scope remediation must explain how to recreate the branch: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Rerun"),
+        "invalid scope must not advertise a rereview command that cannot succeed: {stderr}"
+    );
     assert_eq!(repo.snapshot(), before);
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2362,6 +2362,300 @@ fn test_rereview_downgrades_ambiguous_identical_rename_across_executable_mode() 
     assert_eq!(repo.worktree_diff(), repo.diff("HEAD", &endpoint));
 }
 
+#[test]
+fn test_rereview_downgrades_target_side_ambiguous_identical_rename() {
+    let repo = TempGitRepo::new();
+    repo.write_file("target-left.txt", "identical target rename content\n");
+    repo.write_file("target-right.txt", "identical target rename content\n");
+    repo.git(&["add", "."]);
+    repo.commit("Add target-side rename candidates");
+    repo.git(&["push", "origin", "main"]);
+
+    repo.create_branch("develop");
+    repo.write_file("target-left.txt", "approved candidate modification\n");
+    repo.write_file("unrelated-approved.txt", "unrelated approved content\n");
+    repo.git(&["add", "."]);
+    repo.commit("Approve one candidate and an unrelated addition");
+    repo.git(&["push", "-u", "origin", "develop"]);
+    repo.switch_branch("main");
+    assert!(repo
+        .run_cresca(&["review", "main", "develop"])
+        .status
+        .success());
+    repo.git(&["add", "target-left.txt", "unrelated-approved.txt"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+
+    repo.switch_branch("main");
+    repo.git(&["rm", "target-left.txt", "target-right.txt"]);
+    repo.write_file("target-renamed.txt", "identical target rename content\n");
+    let mut permissions = std::fs::metadata(repo.path().join("target-renamed.txt"))
+        .expect("target rename destination should exist")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(repo.path().join("target-renamed.txt"), permissions)
+        .expect("target rename destination should become executable");
+    repo.git(&["add", "."]);
+    repo.commit("Ambiguously rename identical candidates on target");
+    repo.git(&["push", "origin", "main"]);
+    let new_base = repo.rev_parse("HEAD");
+
+    repo.git(&["checkout", "-b", "expected-target-ambiguity", &new_base]);
+    repo.write_file("unrelated-approved.txt", "unrelated approved content\n");
+    repo.git(&["add", "unrelated-approved.txt"]);
+    repo.commit("Build expected target ambiguity tree");
+    let expected_tree = repo.rev_parse("HEAD^{tree}");
+
+    repo.git(&["checkout", "-B", "develop", &new_base]);
+    repo.write_file("target-renamed.txt", "approved candidate modification\n");
+    repo.write_file("unrelated-approved.txt", "unrelated approved content\n");
+    repo.write_file("later.txt", "unreviewed endpoint content\n");
+    repo.git(&["add", "."]);
+    repo.commit("Reapply source after target-side ambiguous rename");
+    let endpoint = repo.rev_parse("HEAD");
+    repo.git(&["push", "--force", "origin", "develop"]);
+    repo.switch_branch("review-main-develop");
+
+    let output = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(repo.rev_parse("HEAD^{tree}"), expected_tree);
+    assert_eq!(
+        repo.git_stdout(&["show", "HEAD:target-renamed.txt"]),
+        "identical target rename content"
+    );
+    assert_eq!(
+        repo.git_stdout(&["show", "HEAD:unrelated-approved.txt"]),
+        "unrelated approved content"
+    );
+    assert_eq!(repo.worktree_diff(), repo.diff("HEAD", &endpoint));
+}
+
+#[test]
+fn test_rereview_treats_repository_conflict_paths_as_literal_pathspecs() {
+    let repo = TempGitRepo::new();
+    let path_pairs = [
+        ("wild*.bin", "wild-neighbor.bin"),
+        ("question?.bin", "questionX.bin"),
+        ("bracket[ab].bin", "bracketa.bin"),
+        (":(glob)magic*.bin", "magic-neighbor.bin"),
+    ];
+    for (unsafe_path, neighbor) in path_pairs {
+        std::fs::write(repo.path().join(unsafe_path), b"base unsafe\0content")
+            .expect("unsafe base path should be writable");
+        std::fs::write(repo.path().join(neighbor), b"base neighbor\0content")
+            .expect("neighbor base path should be writable");
+    }
+    repo.git(&["add", "-A"]);
+    repo.commit("Add literal conflict path fixtures");
+    repo.git(&["push", "origin", "main"]);
+
+    repo.create_branch("develop");
+    for (unsafe_path, neighbor) in path_pairs {
+        std::fs::write(repo.path().join(unsafe_path), b"approved unsafe\0content")
+            .expect("unsafe approved path should be writable");
+        std::fs::write(repo.path().join(neighbor), b"approved neighbor\0content")
+            .expect("neighbor approved path should be writable");
+    }
+    repo.write_file("unrelated-approved.txt", "unrelated approved content\n");
+    repo.git(&["add", "-A"]);
+    repo.commit("Approve literal conflict paths and neighbors");
+    repo.git(&["push", "-u", "origin", "develop"]);
+    repo.switch_branch("main");
+    assert!(repo
+        .run_cresca(&["review", "main", "develop"])
+        .status
+        .success());
+    repo.git(&["add", "-A"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+
+    repo.switch_branch("main");
+    for (unsafe_path, _) in path_pairs {
+        std::fs::write(repo.path().join(unsafe_path), b"target unsafe\0content")
+            .expect("unsafe target path should be writable");
+    }
+    repo.git(&["add", "-A"]);
+    repo.commit("Conflict on literal pathspec names");
+    repo.git(&["push", "origin", "main"]);
+    let new_base = repo.rev_parse("HEAD");
+
+    repo.git(&["checkout", "-b", "expected-literal-conflicts", &new_base]);
+    for (_, neighbor) in path_pairs {
+        std::fs::write(repo.path().join(neighbor), b"approved neighbor\0content")
+            .expect("expected neighbor path should be writable");
+    }
+    repo.write_file("unrelated-approved.txt", "unrelated approved content\n");
+    repo.git(&["add", "-A"]);
+    repo.commit("Build expected literal conflict tree");
+    let expected_tree = repo.rev_parse("HEAD^{tree}");
+
+    repo.git(&["checkout", "-B", "develop", &new_base]);
+    for (unsafe_path, neighbor) in path_pairs {
+        std::fs::write(repo.path().join(unsafe_path), b"approved unsafe\0content")
+            .expect("rebased unsafe path should be writable");
+        std::fs::write(repo.path().join(neighbor), b"approved neighbor\0content")
+            .expect("rebased neighbor path should be writable");
+    }
+    repo.write_file("unrelated-approved.txt", "unrelated approved content\n");
+    repo.write_file("later.txt", "unreviewed endpoint content\n");
+    repo.git(&["add", "-A"]);
+    repo.commit("Reapply literal conflict source changes");
+    let endpoint = repo.rev_parse("HEAD");
+    repo.git(&["push", "--force", "origin", "develop"]);
+    repo.switch_branch("review-main-develop");
+
+    let output = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(repo.rev_parse("HEAD^{tree}"), expected_tree);
+    for (unsafe_path, neighbor) in path_pairs {
+        assert_eq!(
+            repo.git(&["show", &format!("HEAD:{unsafe_path}")]).stdout,
+            b"target unsafe\0content"
+        );
+        assert_eq!(
+            repo.git(&["show", &format!("HEAD:{neighbor}")]).stdout,
+            b"approved neighbor\0content"
+        );
+    }
+    assert_eq!(repo.worktree_diff(), repo.diff("HEAD", &endpoint));
+}
+
+#[test]
+fn test_rereview_treats_repository_ambiguity_paths_as_literal_pathspecs() {
+    let repo = TempGitRepo::new();
+    let path_groups = [
+        (
+            "star*.txt",
+            "star-source.txt",
+            "star-renamed.txt",
+            "star-neighbor.txt",
+            "star group content\n",
+        ),
+        (
+            "question?.txt",
+            "questionA.txt",
+            "questionB.txt",
+            "questionN.txt",
+            "question group content\n",
+        ),
+        (
+            "bracket[ab].txt",
+            "bracketa.txt",
+            "bracket-renamed.txt",
+            "bracketb.txt",
+            "bracket group content\n",
+        ),
+        (
+            ":(glob)colon*.txt",
+            "colon-source.txt",
+            "colon-renamed.txt",
+            "colon-neighbor.txt",
+            "colon group content\n",
+        ),
+    ];
+    for (unsafe_path, second_candidate, _, neighbor, content) in path_groups {
+        repo.write_file(unsafe_path, content);
+        repo.write_file(second_candidate, content);
+        repo.write_file(neighbor, "base neighbor content\n");
+    }
+    repo.git(&["add", "-A"]);
+    repo.commit("Add literal ambiguity path fixtures");
+    repo.git(&["push", "origin", "main"]);
+
+    repo.create_branch("develop");
+    for (unsafe_path, second_candidate, destination, neighbor, content) in path_groups {
+        repo.git(&[
+            "--literal-pathspecs",
+            "rm",
+            "--",
+            unsafe_path,
+            second_candidate,
+        ]);
+        repo.write_file(destination, content);
+        repo.write_file(neighbor, "approved neighbor content\n");
+    }
+    repo.write_file("unrelated-approved.txt", "unrelated approved content\n");
+    repo.git(&["add", "-A"]);
+    repo.commit("Approve literal ambiguity paths and neighbors");
+    repo.git(&["push", "-u", "origin", "develop"]);
+    repo.switch_branch("main");
+    assert!(repo
+        .run_cresca(&["review", "main", "develop"])
+        .status
+        .success());
+    repo.git(&["add", "-A"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+
+    repo.switch_branch("main");
+    repo.write_file("target-only.txt", "new target baseline\n");
+    repo.git(&["add", "target-only.txt"]);
+    repo.commit("Advance target for literal ambiguity reconstruction");
+    repo.git(&["push", "origin", "main"]);
+    let new_base = repo.rev_parse("HEAD");
+
+    repo.git(&["checkout", "-b", "expected-literal-ambiguity", &new_base]);
+    for (_, _, _, neighbor, _) in path_groups {
+        repo.write_file(neighbor, "approved neighbor content\n");
+    }
+    repo.write_file("unrelated-approved.txt", "unrelated approved content\n");
+    repo.git(&["add", "-A"]);
+    repo.commit("Build expected literal ambiguity tree");
+    let expected_tree = repo.rev_parse("HEAD^{tree}");
+
+    repo.git(&["checkout", "-B", "develop", &new_base]);
+    for (unsafe_path, second_candidate, destination, neighbor, content) in path_groups {
+        repo.git(&[
+            "--literal-pathspecs",
+            "rm",
+            "--",
+            unsafe_path,
+            second_candidate,
+        ]);
+        repo.write_file(destination, content);
+        repo.write_file(neighbor, "approved neighbor content\n");
+    }
+    repo.write_file("unrelated-approved.txt", "unrelated approved content\n");
+    repo.write_file("later.txt", "unreviewed endpoint content\n");
+    repo.git(&["add", "-A"]);
+    repo.commit("Reapply literal ambiguity source changes");
+    let endpoint = repo.rev_parse("HEAD");
+    repo.git(&["push", "--force", "origin", "develop"]);
+    repo.switch_branch("review-main-develop");
+
+    let output = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(repo.rev_parse("HEAD^{tree}"), expected_tree);
+    for (unsafe_path, second_candidate, destination, neighbor, content) in path_groups {
+        assert_eq!(
+            repo.git_stdout(&["show", &format!("HEAD:{unsafe_path}")]),
+            content.trim_end()
+        );
+        assert_eq!(
+            repo.git_stdout(&["show", &format!("HEAD:{second_candidate}")]),
+            content.trim_end()
+        );
+        assert!(!repo
+            .git_maybe(&["cat-file", "-e", &format!("HEAD:{destination}")])
+            .status
+            .success());
+        assert_eq!(
+            repo.git_stdout(&["show", &format!("HEAD:{neighbor}")]),
+            "approved neighbor content"
+        );
+    }
+    assert_eq!(repo.worktree_diff(), repo.diff("HEAD", &endpoint));
+}
+
 /// Test that `cresca review --skip-to` auto-approves earlier commits.
 #[test]
 fn test_review_with_skip_to_option() {
@@ -3842,6 +4136,80 @@ fn test_status_all_ignores_explicit_base_marker_in_current_target_ancestry() {
     assert!(all.contains("    - later.txt\n"), "{all}");
     assert!(!all.contains("legacy-approved.txt"), "{all}");
     assert!(!all.contains("current-target-only.txt"), "{all}");
+    assert!(!all.contains("next-approved.txt"), "{all}");
+    assert_eq!(repo.snapshot(), before);
+}
+
+#[test]
+fn test_status_all_ignores_inherited_target_marker_after_source_rebases_earlier() {
+    let repo = TempGitRepo::new();
+    repo.create_branch("legacy");
+    repo.write_file("legacy-approved.txt", "legacy approved content\n");
+    repo.git(&["add", "legacy-approved.txt"]);
+    repo.commit("Add legacy source content");
+    repo.git(&["push", "-u", "origin", "legacy"]);
+    repo.switch_branch("main");
+    assert!(repo
+        .run_cresca(&["review", "main", "legacy"])
+        .status
+        .success());
+    repo.git(&["add", "legacy-approved.txt"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+
+    repo.switch_branch("main");
+    repo.write_file("legacy-target-base.txt", "legacy target baseline\n");
+    repo.git(&["add", "legacy-target-base.txt"]);
+    repo.commit("Advance target before legacy rereview");
+    repo.git(&["push", "origin", "main"]);
+    repo.git(&["checkout", "-B", "legacy", "main"]);
+    repo.write_file("legacy-approved.txt", "legacy approved content\n");
+    repo.git(&["add", "legacy-approved.txt"]);
+    repo.commit("Rebase legacy source");
+    repo.git(&["push", "--force", "origin", "legacy"]);
+    repo.switch_branch("review-main-legacy");
+    assert!(repo
+        .run_cresca(&["review", "main", "legacy"])
+        .status
+        .success());
+    let adopted_target = repo.rev_parse("HEAD");
+    let earlier_target_ancestor = repo.rev_parse("HEAD^");
+    assert!(repo
+        .git_stdout(&["show", "-s", "--format=%B", &adopted_target])
+        .contains("Cresca-Review-Base: "));
+
+    repo.git(&["branch", "-f", "main", &adopted_target]);
+    repo.switch_branch("main");
+    repo.git(&["push", "--force", "origin", "main"]);
+    repo.create_branch("next");
+    repo.write_file("next-approved.txt", "next approved content\n");
+    repo.git(&["add", "next-approved.txt"]);
+    repo.commit("Add next source content");
+    repo.git(&["push", "-u", "origin", "next"]);
+    repo.switch_branch("main");
+    assert!(repo
+        .run_cresca(&["review", "main", "next"])
+        .status
+        .success());
+    repo.git(&["add", "next-approved.txt"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+
+    repo.git(&["checkout", "-B", "next", &earlier_target_ancestor]);
+    repo.write_file("next-approved.txt", "next approved content\n");
+    repo.write_file("later.txt", "later next-source content\n");
+    repo.git(&["add", "."]);
+    repo.commit("Force-rebase next source before inherited marker");
+    repo.git(&["push", "--force", "origin", "next"]);
+    repo.switch_branch("review-main-next");
+
+    let before = repo.snapshot();
+    let all = run_status_stdout(&repo, &["status", "--all"]);
+    assert!(
+        all.contains("2 file(s), +1 insertion(s), -1 deletion(s)"),
+        "{all}"
+    );
+    assert!(all.contains("    - later.txt\n"), "{all}");
+    assert!(all.contains("    - legacy-target-base.txt\n"), "{all}");
+    assert!(!all.contains("legacy-approved.txt"), "{all}");
     assert!(!all.contains("next-approved.txt"), "{all}");
     assert_eq!(repo.snapshot(), before);
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1472,6 +1472,55 @@ fn test_review_includes_all_changes_from_source_only_merge() {
 }
 
 #[test]
+fn test_review_excludes_target_only_changes_after_clean_target_merge() {
+    let repo = TempGitRepo::new();
+    repo.create_branch("develop");
+    repo.write_file(
+        "source-before-merge.txt",
+        "source work before target merge\n",
+    );
+    repo.git(&["add", "source-before-merge.txt"]);
+    repo.commit("Add source work before target merge");
+    repo.switch_branch("main");
+    repo.write_file("target-only.txt", "updated target baseline\n");
+    repo.git(&["add", "target-only.txt"]);
+    repo.commit("Advance target independently");
+    repo.git(&["push", "origin", "main"]);
+    let updated_target = repo.rev_parse("HEAD");
+    repo.switch_branch("develop");
+    repo.git(&[
+        "merge",
+        "--no-ff",
+        "main",
+        "-m",
+        "Merge updated target cleanly",
+    ]);
+    repo.write_file("source-after-merge.txt", "source work after target merge\n");
+    repo.git(&["add", "source-after-merge.txt"]);
+    repo.commit("Add source work after target merge");
+    let endpoint = repo.rev_parse("HEAD");
+    repo.git(&["push", "-u", "origin", "develop"]);
+    repo.switch_branch("main");
+
+    let output = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(repo.rev_parse("HEAD"), updated_target);
+    assert_eq!(repo.worktree_diff(), repo.diff(&updated_target, &endpoint));
+    let status = repo.git_stdout(&["status", "--porcelain", "--untracked-files=all"]);
+    assert!(status.contains("source-before-merge.txt"), "{status}");
+    assert!(status.contains("source-after-merge.txt"), "{status}");
+    assert!(!status.contains("target-only.txt"), "{status}");
+    assert_eq!(
+        repo.read_file("target-only.txt"),
+        "updated target baseline\n"
+    );
+}
+
+#[test]
 fn test_review_uses_endpoint_tree_when_addition_and_deletion_cancel() {
     let repo = TempGitRepo::new();
     let base = repo.rev_parse("HEAD");
@@ -2166,6 +2215,75 @@ fn test_rereview_handles_mode_symlink_modify_delete_and_rename_delete_safely() {
     );
     assert!(repo.path().join("modify-delete.txt").exists());
     assert!(repo.path().join("rename-approved.txt").exists());
+}
+
+#[test]
+fn test_rereview_does_not_transfer_approval_through_ambiguous_identical_rename() {
+    let repo = TempGitRepo::new();
+    repo.write_file("left.txt", "identical base content\n");
+    repo.write_file("right.txt", "identical base content\n");
+    repo.git(&["add", "."]);
+    repo.commit("Add identical rename candidates");
+    repo.git(&["push", "origin", "main"]);
+    repo.create_branch("develop");
+    repo.git(&["rm", "left.txt", "right.txt"]);
+    repo.write_file("renamed-identical.txt", "identical base content\n");
+    repo.write_file("approved-addition.txt", "unambiguous approved addition\n");
+    repo.git(&["add", "."]);
+    repo.commit("Create ambiguous identical rename approval");
+    repo.git(&["push", "-u", "origin", "develop"]);
+    repo.switch_branch("main");
+    assert!(repo
+        .run_cresca(&["review", "main", "develop"])
+        .status
+        .success());
+    repo.git(&["add", "-A"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+
+    repo.switch_branch("main");
+    repo.write_file("left.txt", "new target left content\n");
+    repo.write_file("right.txt", "new target right content\n");
+    repo.git(&["add", "."]);
+    repo.commit("Change both ambiguous target candidates");
+    repo.git(&["push", "origin", "main"]);
+    let new_base = repo.rev_parse("HEAD");
+    repo.git(&["checkout", "-B", "develop", "main"]);
+    repo.git(&["rm", "left.txt", "right.txt"]);
+    repo.write_file("renamed-identical.txt", "identical base content\n");
+    repo.write_file("approved-addition.txt", "unambiguous approved addition\n");
+    repo.git(&["add", "."]);
+    repo.commit("Reapply ambiguous rename after base movement");
+    let endpoint = repo.rev_parse("HEAD");
+    repo.git(&["push", "--force", "origin", "develop"]);
+    repo.switch_branch("review-main-develop");
+
+    let output = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        repo.git_stdout(&["show", "HEAD:left.txt"]),
+        "new target left content"
+    );
+    assert_eq!(
+        repo.git_stdout(&["show", "HEAD:right.txt"]),
+        "new target right content"
+    );
+    assert!(!repo
+        .git_maybe(&["cat-file", "-e", "HEAD:renamed-identical.txt"])
+        .status
+        .success());
+    assert_eq!(
+        repo.git_stdout(&["show", "HEAD:approved-addition.txt"]),
+        "unambiguous approved addition"
+    );
+    assert_eq!(repo.worktree_diff(), repo.diff("HEAD", &endpoint));
+    assert_ne!(
+        repo.rev_parse("HEAD^{tree}"),
+        repo.rev_parse(&format!("{new_base}^{{tree}}"))
+    );
 }
 
 /// Test that `cresca review --skip-to` auto-approves earlier commits.
@@ -3393,7 +3511,7 @@ fn test_status_rejects_unavailable_scope_commit_but_all_still_works() {
     ]);
     assert_scope_error_and_all_available(
         &repo,
-        &format!("saved range endpoint '{oid}' is unavailable"),
+        &format!("saved review object '{oid}' is unavailable"),
     );
 }
 
@@ -3410,7 +3528,7 @@ fn test_status_reports_missing_version_two_base_oid() {
     ]);
     assert_scope_error_and_all_available(
         &repo,
-        &format!("saved range endpoint '{missing_base}' is unavailable"),
+        &format!("saved review object '{missing_base}' is unavailable"),
     );
 }
 
@@ -3563,6 +3681,92 @@ fn test_status_all_uses_latest_explicit_base_after_repeated_base_updates() {
     assert!(!all.contains("second-target-only.txt"), "{all}");
     assert!(!all.contains("approved.txt"), "{all}");
     assert!(!all.contains("approved-after-first.txt"), "{all}");
+    assert_eq!(repo.snapshot(), before);
+}
+
+#[test]
+fn test_status_all_ignores_explicit_base_marker_in_current_target_ancestry() {
+    let repo = TempGitRepo::new();
+    repo.create_branch("legacy");
+    repo.write_file("legacy-approved.txt", "legacy approved content\n");
+    repo.git(&["add", "legacy-approved.txt"]);
+    repo.commit("Add legacy source content");
+    repo.git(&["push", "-u", "origin", "legacy"]);
+    repo.switch_branch("main");
+    assert!(repo
+        .run_cresca(&["review", "main", "legacy"])
+        .status
+        .success());
+    repo.git(&["add", "legacy-approved.txt"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+
+    repo.switch_branch("main");
+    repo.write_file("legacy-target-base.txt", "legacy target baseline\n");
+    repo.git(&["add", "legacy-target-base.txt"]);
+    repo.commit("Advance target before legacy rereview");
+    repo.git(&["push", "origin", "main"]);
+    repo.git(&["checkout", "-B", "legacy", "main"]);
+    repo.write_file("legacy-approved.txt", "legacy approved content\n");
+    repo.git(&["add", "legacy-approved.txt"]);
+    repo.commit("Rebase legacy source");
+    repo.git(&["push", "--force", "origin", "legacy"]);
+    repo.switch_branch("review-main-legacy");
+    assert!(repo
+        .run_cresca(&["review", "main", "legacy"])
+        .status
+        .success());
+    let adopted_target = repo.rev_parse("HEAD");
+    assert!(repo
+        .git_stdout(&["show", "-s", "--format=%B", &adopted_target])
+        .contains("Cresca-Review-Base: "));
+
+    repo.git(&["branch", "-f", "main", &adopted_target]);
+    repo.switch_branch("main");
+    repo.git(&["push", "--force", "origin", "main"]);
+    repo.create_branch("next");
+    repo.write_file("next-approved.txt", "next approved content\n");
+    repo.git(&["add", "next-approved.txt"]);
+    repo.commit("Add next source content");
+    repo.git(&["push", "-u", "origin", "next"]);
+    repo.switch_branch("main");
+    assert!(repo
+        .run_cresca(&["review", "main", "next"])
+        .status
+        .success());
+    assert_eq!(repo.rev_parse("HEAD"), adopted_target);
+    repo.git(&["add", "next-approved.txt"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+
+    repo.switch_branch("main");
+    repo.git(&["rm", "legacy-approved.txt"]);
+    repo.write_file("current-target-only.txt", "current target baseline\n");
+    repo.git(&["add", "current-target-only.txt"]);
+    repo.commit("Advance target after new review starts");
+    repo.git(&["push", "origin", "main"]);
+    repo.git(&["checkout", "-B", "next", "main"]);
+    repo.write_file("next-approved.txt", "next approved content\n");
+    repo.write_file("later.txt", "later next-source content\n");
+    repo.git(&["add", "."]);
+    repo.commit("Rebase next source and add later work");
+    repo.git(&["push", "--force", "origin", "next"]);
+    repo.switch_branch("review-main-next");
+    repo.git(&[
+        "config",
+        "--local",
+        "branch.review-main-next.cresca-scope",
+        "malformed",
+    ]);
+
+    let before = repo.snapshot();
+    let all = run_status_stdout(&repo, &["status", "--all"]);
+    assert!(
+        all.contains("1 file(s), +1 insertion(s), -0 deletion(s)"),
+        "{all}"
+    );
+    assert!(all.contains("    - later.txt\n"), "{all}");
+    assert!(!all.contains("legacy-approved.txt"), "{all}");
+    assert!(!all.contains("current-target-only.txt"), "{all}");
+    assert!(!all.contains("next-approved.txt"), "{all}");
     assert_eq!(repo.snapshot(), before);
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -384,7 +384,7 @@ fn test_partial_reconcile_failure_still_restores_independent_paths() {
 }
 
 #[test]
-fn test_successful_review_publishes_fetched_source_for_status_all() {
+fn test_successful_review_publishes_fetched_source_tracking_ref() {
     let (repo, _) = setup_linear_range();
     let stale_source = repo.rev_parse("refs/remotes/origin/develop");
     repo.switch_branch("develop");
@@ -408,8 +408,6 @@ fn test_successful_review_publishes_fetched_source_for_status_all() {
         advanced_source,
         "successful review must publish the source fetched during preflight"
     );
-    let all = run_status_stdout(&repo, &["status", "--all"]);
-    assert!(all.contains("    - advanced-source.txt\n"), "{all}");
 }
 
 #[test]
@@ -3777,7 +3775,7 @@ fn test_status_uses_metadata_for_hyphenated_target_and_slash_source() {
     assert!(output.stderr.is_empty());
 }
 
-fn assert_scope_error_and_all_available(repo: &TempGitRepo, expected_error: &str) {
+fn assert_scope_error_preserves_state(repo: &TempGitRepo, expected_error: &str) {
     let before = repo.snapshot();
     let output = repo.run_cresca(&["status"]);
     assert!(!output.status.success());
@@ -3788,28 +3786,17 @@ fn assert_scope_error_and_all_available(repo: &TempGitRepo, expected_error: &str
         "unexpected diagnostic: {stderr}"
     );
     assert!(stderr.contains("cresca review main develop"));
-    assert!(stderr.contains("cresca status --all"));
     assert_eq!(repo.snapshot(), before);
-
-    let all = repo.run_cresca(&["status", "--all"]);
-    assert!(
-        all.status.success(),
-        "stdout: {}\nstderr: {}",
-        String::from_utf8_lossy(&all.stdout),
-        String::from_utf8_lossy(&all.stderr)
-    );
-    assert!(String::from_utf8_lossy(&all.stdout).contains("    - develop.txt\n"));
-    assert!(all.stderr.is_empty());
 }
 
 #[test]
-fn test_status_requires_scope_metadata_but_all_works_for_pr12_identity() {
+fn test_status_requires_scope_metadata_for_pr12_identity() {
     let repo = setup_identity_only_review_branch();
-    assert_scope_error_and_all_available(&repo, "range metadata is missing");
+    assert_scope_error_preserves_state(&repo, "range metadata is missing");
 }
 
 #[test]
-fn test_status_rejects_duplicate_scope_values_but_all_still_works() {
+fn test_status_rejects_duplicate_scope_values() {
     let repo = setup_identity_only_review_branch();
     let value = format!("1:{}", repo.rev_parse("HEAD"));
     repo.git(&[
@@ -3826,11 +3813,11 @@ fn test_status_rejects_duplicate_scope_values_but_all_still_works() {
         "branch.review-main-develop.cresca-scope",
         &value,
     ]);
-    assert_scope_error_and_all_available(&repo, "range metadata has duplicate values");
+    assert_scope_error_preserves_state(&repo, "range metadata has duplicate values");
 }
 
 #[test]
-fn test_status_rejects_unsupported_scope_version_but_all_still_works() {
+fn test_status_rejects_unsupported_scope_version() {
     let repo = setup_identity_only_review_branch();
     let value = format!("3:{}", repo.rev_parse("HEAD"));
     repo.git(&[
@@ -3839,11 +3826,11 @@ fn test_status_rejects_unsupported_scope_version_but_all_still_works() {
         "branch.review-main-develop.cresca-scope",
         &value,
     ]);
-    assert_scope_error_and_all_available(&repo, "range metadata version '3' is unsupported");
+    assert_scope_error_preserves_state(&repo, "range metadata version '3' is unsupported");
 }
 
 #[test]
-fn test_status_rejects_malformed_scope_oid_but_all_still_works() {
+fn test_status_rejects_malformed_scope_oid() {
     let repo = setup_identity_only_review_branch();
     repo.git(&[
         "config",
@@ -3851,7 +3838,7 @@ fn test_status_rejects_malformed_scope_oid_but_all_still_works() {
         "branch.review-main-develop.cresca-scope",
         "1:not-an-oid",
     ]);
-    assert_scope_error_and_all_available(&repo, "range metadata is invalid");
+    assert_scope_error_preserves_state(&repo, "range metadata is invalid");
 }
 
 #[test]
@@ -3865,11 +3852,11 @@ fn test_status_rejects_abbreviated_scope_oid() {
         "branch.review-main-develop.cresca-scope",
         &value,
     ]);
-    assert_scope_error_and_all_available(&repo, "range metadata is invalid");
+    assert_scope_error_preserves_state(&repo, "range metadata is invalid");
 }
 
 #[test]
-fn test_status_rejects_unavailable_scope_commit_but_all_still_works() {
+fn test_status_rejects_unavailable_scope_commit() {
     let repo = setup_identity_only_review_branch();
     let oid = "0000000000000000000000000000000000000000";
     let value = format!("1:{oid}");
@@ -3879,7 +3866,7 @@ fn test_status_rejects_unavailable_scope_commit_but_all_still_works() {
         "branch.review-main-develop.cresca-scope",
         &value,
     ]);
-    assert_scope_error_and_all_available(
+    assert_scope_error_preserves_state(
         &repo,
         &format!("saved review object '{oid}' is unavailable"),
     );
@@ -3896,7 +3883,7 @@ fn test_status_reports_missing_version_two_base_oid() {
         "branch.review-main-develop.cresca-scope",
         &format!("2:{missing_base}:{endpoint}"),
     ]);
-    assert_scope_error_and_all_available(
+    assert_scope_error_preserves_state(
         &repo,
         &format!("saved review object '{missing_base}' is unavailable"),
     );
@@ -3924,409 +3911,10 @@ fn test_status_keeps_unbounded_review_tip_fixed_until_next_review() {
             "  Remaining diff in current review range: 0 file(s), +0 insertion(s), -0 deletion(s)\n",
         )
     );
-    assert_eq!(
-        run_status_stdout(&repo, &["status", "--all"]),
-        concat!(
-            "📋 Review status (full pull request):\n",
-            "  Remaining diff to develop: 1 file(s), +1 insertion(s), -0 deletion(s)\n",
-            "  Files remaining:\n",
-            "    - e.txt\n",
-        )
-    );
 }
 
 #[test]
-fn test_status_all_temporarily_reconstructs_after_target_and_source_rebase_without_mutation() {
-    let repo = TempGitRepo::new();
-    repo.create_branch("develop");
-    repo.write_file("approved.txt", "approved content\n");
-    repo.git(&["add", "approved.txt"]);
-    repo.commit("Add approved source content");
-    repo.git(&["push", "-u", "origin", "develop"]);
-    repo.switch_branch("main");
-    assert!(repo
-        .run_cresca(&["review", "main", "develop"])
-        .status
-        .success());
-    repo.git(&["add", "approved.txt"]);
-    assert!(repo.run_cresca(&["approve"]).status.success());
-
-    repo.switch_branch("main");
-    repo.write_file("target-only.txt", "new target baseline\n");
-    repo.git(&["add", "target-only.txt"]);
-    repo.commit("Advance target baseline");
-    repo.git(&["push", "origin", "main"]);
-    repo.git(&["checkout", "-B", "develop", "main"]);
-    repo.write_file("approved.txt", "approved content\n");
-    repo.write_file("later.txt", "new unreviewed content\n");
-    repo.git(&["add", "."]);
-    repo.commit("Rebase approved content and add later change");
-    repo.git(&["push", "--force", "origin", "develop"]);
-    repo.switch_branch("review-main-develop");
-
-    let before = repo.snapshot();
-    let objects_before = repo.git_stdout(&["count-objects", "-v"]);
-    let all = run_status_stdout(&repo, &["status", "--all"]);
-    assert!(
-        all.contains("1 file(s), +1 insertion(s), -0 deletion(s)"),
-        "{all}"
-    );
-    assert!(all.contains("    - later.txt\n"), "{all}");
-    assert!(!all.contains("target-only.txt"), "{all}");
-    assert!(!all.contains("approved.txt"), "{all}");
-    assert_eq!(repo.snapshot(), before);
-    assert_eq!(repo.git_stdout(&["count-objects", "-v"]), objects_before);
-}
-
-#[test]
-fn test_status_all_uses_latest_explicit_base_after_repeated_base_updates() {
-    let repo = TempGitRepo::new();
-    repo.write_file("deleted-from-target.txt", "initial target content\n");
-    repo.git(&["add", "deleted-from-target.txt"]);
-    repo.commit("Add initial target fixture");
-    repo.git(&["push", "origin", "main"]);
-    repo.create_branch("develop");
-    repo.write_file("approved.txt", "approved source content\n");
-    repo.git(&["add", "approved.txt"]);
-    repo.commit("Add approved source content");
-    repo.git(&["push", "-u", "origin", "develop"]);
-    repo.switch_branch("main");
-    assert!(repo
-        .run_cresca(&["review", "main", "develop"])
-        .status
-        .success());
-    repo.git(&["add", "approved.txt"]);
-    assert!(repo.run_cresca(&["approve"]).status.success());
-
-    repo.switch_branch("main");
-    repo.git(&["rm", "deleted-from-target.txt"]);
-    repo.write_file("first-target-only.txt", "first target baseline\n");
-    repo.git(&["add", "first-target-only.txt"]);
-    repo.commit("First target base update");
-    repo.git(&["push", "origin", "main"]);
-    repo.git(&["checkout", "-B", "develop", "main"]);
-    repo.write_file("approved.txt", "approved source content\n");
-    repo.write_file("approved-after-first.txt", "approved after first update\n");
-    repo.git(&["add", "approved.txt", "approved-after-first.txt"]);
-    repo.commit("Rebase source after first target update");
-    repo.git(&["push", "--force", "origin", "develop"]);
-    repo.switch_branch("review-main-develop");
-    assert!(repo
-        .run_cresca(&["review", "main", "develop"])
-        .status
-        .success());
-    repo.git(&["add", "approved-after-first.txt"]);
-    assert!(repo.run_cresca(&["approve"]).status.success());
-    assert!(repo.worktree_diff().is_empty());
-
-    repo.switch_branch("main");
-    repo.git(&["rm", "first-target-only.txt"]);
-    repo.write_file("second-target-only.txt", "second target baseline\n");
-    repo.git(&["add", "second-target-only.txt"]);
-    repo.commit("Second target base update");
-    repo.git(&["push", "origin", "main"]);
-    repo.git(&["checkout", "-B", "develop", "main"]);
-    repo.write_file("approved.txt", "approved source content\n");
-    repo.write_file("approved-after-first.txt", "approved after first update\n");
-    repo.write_file("later.txt", "later unreviewed content\n");
-    repo.git(&["add", "."]);
-    repo.commit("Rebase source after second target update");
-    repo.git(&["push", "--force", "origin", "develop"]);
-    repo.switch_branch("review-main-develop");
-    repo.git(&[
-        "config",
-        "--local",
-        "branch.review-main-develop.cresca-scope",
-        "malformed",
-    ]);
-
-    let before = repo.snapshot();
-    let all = run_status_stdout(&repo, &["status", "--all"]);
-    assert!(
-        all.contains("1 file(s), +1 insertion(s), -0 deletion(s)"),
-        "{all}"
-    );
-    assert!(all.contains("    - later.txt\n"), "{all}");
-    assert!(!all.contains("first-target-only.txt"), "{all}");
-    assert!(!all.contains("second-target-only.txt"), "{all}");
-    assert!(!all.contains("approved.txt"), "{all}");
-    assert!(!all.contains("approved-after-first.txt"), "{all}");
-    assert_eq!(repo.snapshot(), before);
-}
-
-#[test]
-fn test_status_all_ignores_explicit_base_marker_in_current_target_ancestry() {
-    let repo = TempGitRepo::new();
-    repo.create_branch("legacy");
-    repo.write_file("legacy-approved.txt", "legacy approved content\n");
-    repo.git(&["add", "legacy-approved.txt"]);
-    repo.commit("Add legacy source content");
-    repo.git(&["push", "-u", "origin", "legacy"]);
-    repo.switch_branch("main");
-    assert!(repo
-        .run_cresca(&["review", "main", "legacy"])
-        .status
-        .success());
-    repo.git(&["add", "legacy-approved.txt"]);
-    assert!(repo.run_cresca(&["approve"]).status.success());
-
-    repo.switch_branch("main");
-    repo.write_file("legacy-target-base.txt", "legacy target baseline\n");
-    repo.git(&["add", "legacy-target-base.txt"]);
-    repo.commit("Advance target before legacy rereview");
-    repo.git(&["push", "origin", "main"]);
-    repo.git(&["checkout", "-B", "legacy", "main"]);
-    repo.write_file("legacy-approved.txt", "legacy approved content\n");
-    repo.git(&["add", "legacy-approved.txt"]);
-    repo.commit("Rebase legacy source");
-    repo.git(&["push", "--force", "origin", "legacy"]);
-    repo.switch_branch("review-main-legacy");
-    assert!(repo
-        .run_cresca(&["review", "main", "legacy"])
-        .status
-        .success());
-    let adopted_target = repo.rev_parse("HEAD");
-    assert!(repo
-        .git_stdout(&["show", "-s", "--format=%B", &adopted_target])
-        .contains("Cresca-Review-Base: "));
-
-    repo.git(&["branch", "-f", "main", &adopted_target]);
-    repo.switch_branch("main");
-    repo.git(&["push", "--force", "origin", "main"]);
-    repo.create_branch("next");
-    repo.write_file("next-approved.txt", "next approved content\n");
-    repo.git(&["add", "next-approved.txt"]);
-    repo.commit("Add next source content");
-    repo.git(&["push", "-u", "origin", "next"]);
-    repo.switch_branch("main");
-    assert!(repo
-        .run_cresca(&["review", "main", "next"])
-        .status
-        .success());
-    assert_eq!(repo.rev_parse("HEAD"), adopted_target);
-    repo.git(&["add", "next-approved.txt"]);
-    assert!(repo.run_cresca(&["approve"]).status.success());
-
-    repo.switch_branch("main");
-    repo.git(&["rm", "legacy-approved.txt"]);
-    repo.write_file("current-target-only.txt", "current target baseline\n");
-    repo.git(&["add", "current-target-only.txt"]);
-    repo.commit("Advance target after new review starts");
-    repo.git(&["push", "origin", "main"]);
-    repo.git(&["checkout", "-B", "next", "main"]);
-    repo.write_file("next-approved.txt", "next approved content\n");
-    repo.write_file("later.txt", "later next-source content\n");
-    repo.git(&["add", "."]);
-    repo.commit("Rebase next source and add later work");
-    repo.git(&["push", "--force", "origin", "next"]);
-    repo.switch_branch("review-main-next");
-    repo.git(&[
-        "config",
-        "--local",
-        "branch.review-main-next.cresca-scope",
-        "malformed",
-    ]);
-
-    let before = repo.snapshot();
-    let all = run_status_stdout(&repo, &["status", "--all"]);
-    assert!(
-        all.contains("1 file(s), +1 insertion(s), -0 deletion(s)"),
-        "{all}"
-    );
-    assert!(all.contains("    - later.txt\n"), "{all}");
-    assert!(!all.contains("legacy-approved.txt"), "{all}");
-    assert!(!all.contains("current-target-only.txt"), "{all}");
-    assert!(!all.contains("next-approved.txt"), "{all}");
-    assert_eq!(repo.snapshot(), before);
-}
-
-#[test]
-fn test_status_all_ignores_inherited_target_marker_after_source_rebases_earlier() {
-    let repo = TempGitRepo::new();
-    repo.create_branch("legacy");
-    repo.write_file("legacy-approved.txt", "legacy approved content\n");
-    repo.git(&["add", "legacy-approved.txt"]);
-    repo.commit("Add legacy source content");
-    repo.git(&["push", "-u", "origin", "legacy"]);
-    repo.switch_branch("main");
-    assert!(repo
-        .run_cresca(&["review", "main", "legacy"])
-        .status
-        .success());
-    repo.git(&["add", "legacy-approved.txt"]);
-    assert!(repo.run_cresca(&["approve"]).status.success());
-
-    repo.switch_branch("main");
-    repo.write_file("legacy-target-base.txt", "legacy target baseline\n");
-    repo.git(&["add", "legacy-target-base.txt"]);
-    repo.commit("Advance target before legacy rereview");
-    repo.git(&["push", "origin", "main"]);
-    repo.git(&["checkout", "-B", "legacy", "main"]);
-    repo.write_file("legacy-approved.txt", "legacy approved content\n");
-    repo.git(&["add", "legacy-approved.txt"]);
-    repo.commit("Rebase legacy source");
-    repo.git(&["push", "--force", "origin", "legacy"]);
-    repo.switch_branch("review-main-legacy");
-    assert!(repo
-        .run_cresca(&["review", "main", "legacy"])
-        .status
-        .success());
-    let adopted_target = repo.rev_parse("HEAD");
-    let earlier_target_ancestor = repo.rev_parse("HEAD^");
-    assert!(repo
-        .git_stdout(&["show", "-s", "--format=%B", &adopted_target])
-        .contains("Cresca-Review-Base: "));
-
-    repo.git(&["branch", "-f", "main", &adopted_target]);
-    repo.switch_branch("main");
-    repo.git(&["push", "--force", "origin", "main"]);
-    repo.create_branch("next");
-    repo.write_file("next-approved.txt", "next approved content\n");
-    repo.git(&["add", "next-approved.txt"]);
-    repo.commit("Add next source content");
-    repo.git(&["push", "-u", "origin", "next"]);
-    repo.switch_branch("main");
-    assert!(repo
-        .run_cresca(&["review", "main", "next"])
-        .status
-        .success());
-    repo.git(&["add", "next-approved.txt"]);
-    assert!(repo.run_cresca(&["approve"]).status.success());
-
-    repo.git(&["checkout", "-B", "next", &earlier_target_ancestor]);
-    repo.write_file("next-approved.txt", "next approved content\n");
-    repo.write_file("later.txt", "later next-source content\n");
-    repo.git(&["add", "."]);
-    repo.commit("Force-rebase next source before inherited marker");
-    repo.git(&["push", "--force", "origin", "next"]);
-    repo.switch_branch("review-main-next");
-
-    let before = repo.snapshot();
-    let all = run_status_stdout(&repo, &["status", "--all"]);
-    assert!(
-        all.contains("2 file(s), +1 insertion(s), -1 deletion(s)"),
-        "{all}"
-    );
-    assert!(all.contains("    - later.txt\n"), "{all}");
-    assert!(all.contains("    - legacy-target-base.txt\n"), "{all}");
-    assert!(!all.contains("legacy-approved.txt"), "{all}");
-    assert!(!all.contains("next-approved.txt"), "{all}");
-    assert_eq!(repo.snapshot(), before);
-}
-
-#[test]
-fn test_status_all_fails_closed_for_unrelated_source_history_without_mutation() {
-    let repo = TempGitRepo::new();
-    repo.git(&["checkout", "--orphan", "develop"]);
-    repo.git(&["rm", "-rf", "."]);
-    repo.write_file("unrelated.txt", "unrelated source\n");
-    repo.git(&["add", "unrelated.txt"]);
-    repo.commit("Create unrelated source history");
-    repo.git(&["push", "-u", "origin", "develop"]);
-    repo.switch_branch("main");
-    repo.create_branch("review-main-develop");
-    repo.git(&[
-        "config",
-        "--local",
-        "branch.review-main-develop.cresca-version",
-        "1",
-    ]);
-    repo.git(&[
-        "config",
-        "--local",
-        "branch.review-main-develop.cresca-target",
-        "main",
-    ]);
-    repo.git(&[
-        "config",
-        "--local",
-        "branch.review-main-develop.cresca-source",
-        "develop",
-    ]);
-    let before = repo.snapshot();
-
-    let output = repo.run_cresca(&["status", "--all"]);
-    assert!(!output.status.success());
-    assert!(
-        String::from_utf8_lossy(&output.stderr).contains("No unique safe merge base"),
-        "{}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert_eq!(repo.snapshot(), before);
-}
-
-#[test]
-fn test_status_all_fails_closed_for_multiple_merge_bases_without_mutation() {
-    let repo = setup_multiple_merge_bases();
-    repo.create_branch("review-main-develop");
-    repo.git(&[
-        "config",
-        "--local",
-        "branch.review-main-develop.cresca-version",
-        "1",
-    ]);
-    repo.git(&[
-        "config",
-        "--local",
-        "branch.review-main-develop.cresca-target",
-        "main",
-    ]);
-    repo.git(&[
-        "config",
-        "--local",
-        "branch.review-main-develop.cresca-source",
-        "develop",
-    ]);
-    let before = repo.snapshot();
-
-    let output = repo.run_cresca(&["status", "--all"]);
-    assert!(!output.status.success());
-    assert!(
-        String::from_utf8_lossy(&output.stderr).contains("Multiple merge bases"),
-        "{}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert_eq!(repo.snapshot(), before);
-}
-
-#[test]
-fn test_status_all_fails_closed_for_ambiguous_explicit_base_correspondence() {
-    let (repo, _) = setup_linear_range();
-    assert!(repo
-        .run_cresca(&["review", "main", "develop"])
-        .status
-        .success());
-    repo.git(&["add", "-A"]);
-    assert!(repo.run_cresca(&["approve"]).status.success());
-    let previous = repo.rev_parse("HEAD");
-    let tree = repo.rev_parse("HEAD^{tree}");
-    let first_base = repo.rev_parse("origin/main");
-    let second_base = repo.rev_parse("origin/develop");
-    let message = format!(
-        "Ambiguous base fixture\n\nCresca-Review-Base: {first_base}\nCresca-Review-Base: {second_base}"
-    );
-    let ambiguous = repo.git_stdout(&["commit-tree", &tree, "-p", &previous, "-m", &message]);
-    repo.git(&[
-        "update-ref",
-        "refs/heads/review-main-develop",
-        &ambiguous,
-        &previous,
-    ]);
-    repo.git(&["reset", "--hard", &ambiguous]);
-    let before = repo.snapshot();
-
-    let output = repo.run_cresca(&["status", "--all"]);
-    assert!(!output.status.success());
-    assert!(
-        String::from_utf8_lossy(&output.stderr).contains("ambiguous explicit base markers"),
-        "{}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert_eq!(repo.snapshot(), before);
-}
-
-#[test]
-fn test_status_default_excludes_commits_after_stop_at_while_all_includes_them() {
+fn test_status_default_excludes_commits_after_stop_at() {
     let (repo, range) = setup_linear_range();
     assert!(repo
         .run_cresca(&["review", "main", "develop", "--stop-at", &range.c[..8],])
@@ -4339,12 +3927,6 @@ fn test_status_default_excludes_commits_after_stop_at_while_all_includes_them() 
     assert!(current.contains("    - removed-at-c.txt\n"));
     assert!(current.contains("    - shared.txt\n"));
     assert!(!current.contains("    - d.txt\n"));
-    let all = run_status_stdout(&repo, &["status", "--all"]);
-    assert!(all.contains("📋 Review status (full pull request):"));
-    assert!(all.contains("4 file(s), +3 insertion(s), -2 deletion(s)"));
-    for file in ["a.txt", "d.txt", "removed-at-c.txt", "shared.txt"] {
-        assert!(all.contains(&format!("    - {file}\n")));
-    }
 }
 
 #[test]
@@ -4369,15 +3951,10 @@ fn test_status_after_skip_stop_and_partial_approve_excludes_auto_approved_change
     assert!(current.contains("    - removed-at-c.txt\n"));
     assert!(!current.contains("a.txt"));
     assert!(!current.contains("d.txt"));
-    let all = run_status_stdout(&repo, &["status", "--all"]);
-    assert!(all.contains("2 file(s), +1 insertion(s), -1 deletion(s)"));
-    assert!(all.contains("    - d.txt\n"));
-    assert!(all.contains("    - removed-at-c.txt\n"));
-    assert!(!all.contains("a.txt"));
 }
 
 #[test]
-fn test_status_current_range_can_be_complete_while_full_pull_request_remains() {
+fn test_status_current_range_can_be_complete() {
     let (repo, range) = setup_linear_range();
     assert!(repo
         .run_cresca(&["review", "main", "develop", "--stop-at", &range.c[..8],])
@@ -4392,27 +3969,17 @@ fn test_status_current_range_can_be_complete_while_full_pull_request_remains() {
             "  Remaining diff in current review range: 0 file(s), +0 insertion(s), -0 deletion(s)\n",
         )
     );
-    assert_eq!(
-        run_status_stdout(&repo, &["status", "--all"]),
-        concat!(
-            "📋 Review status (full pull request):\n",
-            "  Remaining diff to develop: 1 file(s), +1 insertion(s), -0 deletion(s)\n",
-            "  Files remaining:\n",
-            "    - d.txt\n",
-        )
-    );
 }
 
 #[test]
-fn test_status_help_describes_all_scope() {
+fn test_status_rejects_all_option() {
     let repo = TempGitRepo::new();
-    let output = repo.run_cresca(&["status", "--help"]);
-    assert!(output.status.success());
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("Usage: cresca status [OPTIONS]"));
-    assert!(stdout.contains("--all"));
-    assert!(stdout.contains("full pull request"));
-    assert!(output.stderr.is_empty());
+    let before = repo.snapshot();
+    let output = repo.run_cresca(&["status", "--all"]);
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("unexpected argument '--all'"));
+    assert_eq!(repo.snapshot(), before);
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -507,7 +507,8 @@ fn test_fatal_upstream_probe_is_rendered_without_mutation() {
 #[test]
 fn test_fatal_scope_object_probe_is_rendered_without_mutation() {
     let repo = setup_identity_only_review_branch();
-    let scope = format!("1:{}", repo.rev_parse("HEAD"));
+    let endpoint = repo.rev_parse("HEAD");
+    let scope = format!("1:{endpoint}:{endpoint}");
     repo.git(&[
         "config",
         "--local",
@@ -1156,7 +1157,7 @@ fn test_review_records_source_tip_as_full_scope_end_without_stop_at() {
     );
     assert_eq!(
         repo.review_scope_values("review-main-develop"),
-        vec![format!("2:{}:{}", range.base, range.d)]
+        vec![format!("1:{}:{}", range.base, range.d)]
     );
 }
 
@@ -1171,7 +1172,7 @@ fn test_review_records_stop_at_as_full_scope_end() {
     );
     assert_eq!(
         repo.review_scope_values("review-main-develop"),
-        vec![format!("2:{}:{}", range.base, range.c)]
+        vec![format!("1:{}:{}", range.base, range.c)]
     );
 }
 
@@ -1194,7 +1195,7 @@ fn test_review_scope_end_is_independent_of_skip_to() {
     );
     assert_eq!(
         repo.review_scope_values("review-main-develop"),
-        vec![format!("2:{}:{}", range.base, range.c)]
+        vec![format!("1:{}:{}", range.base, range.c)]
     );
 }
 
@@ -1215,7 +1216,7 @@ fn test_successful_rereview_replaces_scope_end() {
     );
     assert_eq!(
         repo.review_scope_values("review-main-develop"),
-        vec![format!("2:{}:{}", range.base, range.d)]
+        vec![format!("1:{}:{}", range.base, range.d)]
     );
 }
 
@@ -1229,7 +1230,7 @@ fn test_failed_rereview_preserves_previous_scope_end() {
     repo.git(&["add", "-A"]);
     assert!(repo.run_cresca(&["approve"]).status.success());
     let before = repo.review_scope_values("review-main-develop");
-    assert_eq!(before, vec![format!("2:{}:{}", range.base, range.c)]);
+    assert_eq!(before, vec![format!("1:{}:{}", range.base, range.c)]);
     let output = repo.run_cresca(&["review", "main", "develop", "--stop-at", "does-not-exist"]);
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -1238,7 +1239,7 @@ fn test_failed_rereview_preserves_previous_scope_end() {
 }
 
 #[test]
-fn test_rereview_migrates_version_one_scope_to_explicit_base() {
+fn test_rereview_rejects_legacy_scope_shape_without_mutation() {
     let (repo, range) = setup_linear_range();
     assert!(repo
         .run_cresca(&["review", "main", "develop", "--stop-at", &range.c[..8]])
@@ -1253,35 +1254,23 @@ fn test_rereview_migrates_version_one_scope_to_explicit_base() {
         &format!("1:{}", range.c),
     ]);
 
+    let before = repo.snapshot();
     let output = repo.run_cresca(&["review", "main", "develop"]);
-    assert!(
-        output.status.success(),
-        "{}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert_eq!(
-        repo.review_scope_values("review-main-develop"),
-        vec![format!("2:{}:{}", range.base, range.d)]
-    );
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("Cannot read existing review range metadata: Invalid"));
+    assert_eq!(repo.snapshot(), before);
 }
 
 #[test]
-fn test_existing_identity_review_without_scope_migrates_only_from_unique_base() {
+fn test_rereview_requires_scope_metadata_without_mutation() {
     let repo = setup_identity_only_review_branch();
-    let old_head = repo.rev_parse("HEAD");
-
+    let before = repo.snapshot();
     let output = repo.run_cresca(&["review", "main", "develop"]);
-    assert!(
-        output.status.success(),
-        "{}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let endpoint = repo.rev_parse("origin/develop");
-    assert_eq!(repo.rev_parse("HEAD^"), old_head);
-    assert_eq!(
-        repo.review_scope_values("review-main-develop"),
-        vec![format!("2:{old_head}:{endpoint}")]
-    );
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("Cannot read existing review range metadata: Missing"));
+    assert_eq!(repo.snapshot(), before);
 }
 
 fn assert_review_matches(
@@ -1935,7 +1924,7 @@ fn test_rereview_reconstructs_approved_tree_after_target_update_and_source_rebas
     assert!(repo.worktree_diff().is_empty());
     assert_eq!(
         repo.review_scope_values("review-main-develop"),
-        vec![format!("2:{new_base}:{endpoint}")]
+        vec![format!("1:{new_base}:{endpoint}")]
     );
 }
 
@@ -3798,7 +3787,8 @@ fn test_status_requires_scope_metadata_for_pr12_identity() {
 #[test]
 fn test_status_rejects_duplicate_scope_values() {
     let repo = setup_identity_only_review_branch();
-    let value = format!("1:{}", repo.rev_parse("HEAD"));
+    let endpoint = repo.rev_parse("HEAD");
+    let value = format!("1:{endpoint}:{endpoint}");
     repo.git(&[
         "config",
         "--local",
@@ -3817,26 +3807,41 @@ fn test_status_rejects_duplicate_scope_values() {
 }
 
 #[test]
-fn test_status_rejects_unsupported_scope_version() {
+fn test_status_rejects_legacy_scope_shape() {
     let repo = setup_identity_only_review_branch();
-    let value = format!("3:{}", repo.rev_parse("HEAD"));
+    let value = format!("1:{}", repo.rev_parse("HEAD"));
     repo.git(&[
         "config",
         "--local",
         "branch.review-main-develop.cresca-scope",
         &value,
     ]);
-    assert_scope_error_preserves_state(&repo, "range metadata version '3' is unsupported");
+    assert_scope_error_preserves_state(&repo, "range metadata is invalid");
+}
+
+#[test]
+fn test_status_rejects_version_two_scope() {
+    let repo = setup_identity_only_review_branch();
+    let endpoint = repo.rev_parse("HEAD");
+    let value = format!("2:{endpoint}:{endpoint}");
+    repo.git(&[
+        "config",
+        "--local",
+        "branch.review-main-develop.cresca-scope",
+        &value,
+    ]);
+    assert_scope_error_preserves_state(&repo, "range metadata version '2' is unsupported");
 }
 
 #[test]
 fn test_status_rejects_malformed_scope_oid() {
     let repo = setup_identity_only_review_branch();
+    let endpoint = repo.rev_parse("HEAD");
     repo.git(&[
         "config",
         "--local",
         "branch.review-main-develop.cresca-scope",
-        "1:not-an-oid",
+        &format!("1:{endpoint}:not-an-oid"),
     ]);
     assert_scope_error_preserves_state(&repo, "range metadata is invalid");
 }
@@ -3845,7 +3850,7 @@ fn test_status_rejects_malformed_scope_oid() {
 fn test_status_rejects_abbreviated_scope_oid() {
     let repo = setup_identity_only_review_branch();
     let head = repo.rev_parse("HEAD");
-    let value = format!("1:{}", &head[..8]);
+    let value = format!("1:{}:{head}", &head[..8]);
     repo.git(&[
         "config",
         "--local",
@@ -3859,7 +3864,7 @@ fn test_status_rejects_abbreviated_scope_oid() {
 fn test_status_rejects_unavailable_scope_commit() {
     let repo = setup_identity_only_review_branch();
     let oid = "0000000000000000000000000000000000000000";
-    let value = format!("1:{oid}");
+    let value = format!("1:{}:{oid}", repo.rev_parse("HEAD"));
     repo.git(&[
         "config",
         "--local",
@@ -3873,7 +3878,7 @@ fn test_status_rejects_unavailable_scope_commit() {
 }
 
 #[test]
-fn test_status_reports_missing_version_two_base_oid() {
+fn test_status_reports_missing_scope_base_oid() {
     let repo = setup_identity_only_review_branch();
     let missing_base = "0000000000000000000000000000000000000000";
     let endpoint = repo.rev_parse("HEAD");
@@ -3881,7 +3886,7 @@ fn test_status_reports_missing_version_two_base_oid() {
         "config",
         "--local",
         "branch.review-main-develop.cresca-scope",
-        &format!("2:{missing_base}:{endpoint}"),
+        &format!("1:{missing_base}:{endpoint}"),
     ]);
     assert_scope_error_preserves_state(
         &repo,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2286,6 +2286,82 @@ fn test_rereview_does_not_transfer_approval_through_ambiguous_identical_rename()
     );
 }
 
+#[test]
+fn test_rereview_downgrades_ambiguous_identical_rename_across_executable_mode() {
+    let repo = TempGitRepo::new();
+    repo.write_file("left-mode.txt", "identical mixed-mode content\n");
+    repo.write_file("right-mode.txt", "identical mixed-mode content\n");
+    repo.git(&["add", "."]);
+    repo.commit("Add mixed-mode rename candidates");
+    repo.git(&["push", "origin", "main"]);
+    repo.create_branch("develop");
+    repo.git(&["rm", "left-mode.txt", "right-mode.txt"]);
+    repo.write_file("renamed-executable.txt", "identical mixed-mode content\n");
+    let mut permissions = std::fs::metadata(repo.path().join("renamed-executable.txt"))
+        .expect("mixed-mode destination should exist")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(repo.path().join("renamed-executable.txt"), permissions)
+        .expect("mixed-mode destination should become executable");
+    repo.write_file("unrelated-approved.txt", "unrelated approved content\n");
+    repo.git(&["add", "."]);
+    repo.commit("Approve ambiguous executable rename");
+    repo.git(&["push", "-u", "origin", "develop"]);
+    repo.switch_branch("main");
+    assert!(repo
+        .run_cresca(&["review", "main", "develop"])
+        .status
+        .success());
+    repo.git(&["add", "-A"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+
+    repo.switch_branch("main");
+    repo.write_file("left-mode.txt", "new target left mode content\n");
+    repo.write_file("right-mode.txt", "new target right mode content\n");
+    repo.git(&["add", "."]);
+    repo.commit("Change mixed-mode target candidates");
+    repo.git(&["push", "origin", "main"]);
+    repo.git(&["checkout", "-B", "develop", "main"]);
+    repo.git(&["rm", "left-mode.txt", "right-mode.txt"]);
+    repo.write_file("renamed-executable.txt", "identical mixed-mode content\n");
+    let mut permissions = std::fs::metadata(repo.path().join("renamed-executable.txt"))
+        .expect("rebased mixed-mode destination should exist")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(repo.path().join("renamed-executable.txt"), permissions)
+        .expect("rebased mixed-mode destination should become executable");
+    repo.write_file("unrelated-approved.txt", "unrelated approved content\n");
+    repo.git(&["add", "."]);
+    repo.commit("Reapply executable rename after base movement");
+    let endpoint = repo.rev_parse("HEAD");
+    repo.git(&["push", "--force", "origin", "develop"]);
+    repo.switch_branch("review-main-develop");
+
+    let output = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        repo.git_stdout(&["show", "HEAD:left-mode.txt"]),
+        "new target left mode content"
+    );
+    assert_eq!(
+        repo.git_stdout(&["show", "HEAD:right-mode.txt"]),
+        "new target right mode content"
+    );
+    assert!(!repo
+        .git_maybe(&["cat-file", "-e", "HEAD:renamed-executable.txt"])
+        .status
+        .success());
+    assert_eq!(
+        repo.git_stdout(&["show", "HEAD:unrelated-approved.txt"]),
+        "unrelated approved content"
+    );
+    assert_eq!(repo.worktree_diff(), repo.diff("HEAD", &endpoint));
+}
+
 /// Test that `cresca review --skip-to` auto-approves earlier commits.
 #[test]
 fn test_review_with_skip_to_option() {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1436,6 +1436,73 @@ fn test_review_materializes_exact_three_dot_diff() {
     assert!(output.stderr.is_empty());
 }
 
+#[test]
+fn test_review_includes_all_changes_from_source_only_merge() {
+    let repo = TempGitRepo::new();
+    let base = repo.rev_parse("HEAD");
+    repo.create_branch("side");
+    repo.write_file("side.txt", "source-only side change\n");
+    repo.git(&["add", "side.txt"]);
+    repo.commit("Add side change");
+    repo.git(&["checkout", "-b", "develop", &base]);
+    repo.write_file("direct.txt", "direct source change\n");
+    repo.git(&["add", "direct.txt"]);
+    repo.commit("Add direct source change");
+    repo.git(&[
+        "merge",
+        "--no-ff",
+        "side",
+        "-m",
+        "Merge source-only side branch",
+    ]);
+    let endpoint = repo.rev_parse("HEAD");
+    repo.git(&["push", "-u", "origin", "develop"]);
+    repo.switch_branch("main");
+
+    let output = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(repo.rev_parse("HEAD"), base);
+    assert_eq!(repo.worktree_diff(), repo.diff(&base, &endpoint));
+    assert_eq!(repo.read_file("direct.txt"), "direct source change\n");
+    assert_eq!(repo.read_file("side.txt"), "source-only side change\n");
+}
+
+#[test]
+fn test_review_uses_endpoint_tree_when_addition_and_deletion_cancel() {
+    let repo = TempGitRepo::new();
+    let base = repo.rev_parse("HEAD");
+    repo.create_branch("develop");
+    repo.write_file("transient.txt", "temporary source content\n");
+    repo.git(&["add", "transient.txt"]);
+    repo.commit("Add transient source file");
+    repo.git(&["rm", "transient.txt"]);
+    repo.commit("Delete transient source file");
+    repo.write_file("lasting.txt", "lasting endpoint content\n");
+    repo.git(&["add", "lasting.txt"]);
+    repo.commit("Add lasting endpoint file");
+    let endpoint = repo.rev_parse("HEAD");
+    repo.git(&["push", "-u", "origin", "develop"]);
+    repo.switch_branch("main");
+
+    let output = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(repo.worktree_diff(), repo.diff(&base, &endpoint));
+    assert!(!repo.path().join("transient.txt").exists());
+    assert_eq!(repo.read_file("lasting.txt"), "lasting endpoint content\n");
+    assert_eq!(
+        repo.git_stdout(&["status", "--porcelain", "--untracked-files=all"]),
+        "?? lasting.txt"
+    );
+}
+
 /// Test that `cresca approve` commits exactly the staged tree and discards everything else.
 #[test]
 fn test_approve_commits_staged() {
@@ -1775,6 +1842,7 @@ fn test_rereview_reconstructs_approved_tree_after_target_update_and_source_rebas
     repo.git(&["add", "approved.txt"]);
     repo.commit("Add source change");
     repo.git(&["push", "-u", "origin", "develop"]);
+    let old_endpoint = repo.rev_parse("HEAD");
     repo.switch_branch("main");
 
     let first = repo.run_cresca(&["review", "main", "develop"]);
@@ -1798,6 +1866,10 @@ fn test_rereview_reconstructs_approved_tree_after_target_update_and_source_rebas
     repo.git(&["rebase", "main"]);
     repo.git(&["push", "--force", "origin", "develop"]);
     let endpoint = repo.rev_parse("HEAD");
+    assert_ne!(
+        endpoint, old_endpoint,
+        "rebase must change source commit identity"
+    );
     repo.switch_branch("review-main-develop");
 
     let rereview = repo.run_cresca(&["review", "main", "develop"]);
@@ -1817,6 +1889,75 @@ fn test_rereview_reconstructs_approved_tree_after_target_update_and_source_rebas
     assert_eq!(
         repo.review_scope_values("review-main-develop"),
         vec![format!("2:{new_base}:{endpoint}")]
+    );
+}
+
+#[test]
+fn test_rereview_preserves_approved_modification_deletion_and_exposes_revert() {
+    let repo = TempGitRepo::new();
+    repo.write_file("modified.txt", "base modification value\n");
+    repo.write_file("deleted.txt", "base deletion value\n");
+    repo.write_file("reverted.txt", "base revert value\n");
+    repo.git(&["add", "."]);
+    repo.commit("Add approval mutation fixtures");
+    repo.git(&["push", "origin", "main"]);
+    repo.create_branch("develop");
+    repo.write_file("modified.txt", "approved modification\n");
+    repo.git(&["rm", "deleted.txt"]);
+    repo.write_file("reverted.txt", "approved intermediate value\n");
+    repo.git(&["add", "."]);
+    repo.commit("Create approved mutations");
+    repo.git(&["push", "-u", "origin", "develop"]);
+    repo.switch_branch("main");
+    assert!(repo
+        .run_cresca(&["review", "main", "develop"])
+        .status
+        .success());
+    repo.git(&["add", "-A"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+
+    repo.switch_branch("develop");
+    repo.write_file("modified.txt", "later modification\n");
+    repo.write_file("deleted.txt", "later recreation\n");
+    repo.write_file("reverted.txt", "base revert value\n");
+    repo.git(&["add", "."]);
+    repo.commit("Advance, recreate, and revert source changes");
+    repo.git(&["push", "origin", "develop"]);
+    repo.switch_branch("review-main-develop");
+
+    let output = repo.run_cresca(&["review", "main", "develop"]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        repo.git_stdout(&["show", "HEAD:modified.txt"]),
+        "approved modification"
+    );
+    assert!(!repo
+        .git_maybe(&["cat-file", "-e", "HEAD:deleted.txt"])
+        .status
+        .success());
+    assert_eq!(
+        repo.git_stdout(&["show", "HEAD:reverted.txt"]),
+        "approved intermediate value"
+    );
+    assert_eq!(repo.read_file("modified.txt"), "later modification\n");
+    assert_eq!(repo.read_file("deleted.txt"), "later recreation\n");
+    assert_eq!(repo.read_file("reverted.txt"), "base revert value\n");
+    let status: BTreeSet<_> = repo
+        .git_stdout(&["status", "--porcelain", "--untracked-files=all"])
+        .lines()
+        .map(str::to_string)
+        .collect();
+    assert_eq!(
+        status,
+        BTreeSet::from([
+            "M modified.txt".to_string(),
+            " M reverted.txt".to_string(),
+            "?? deleted.txt".to_string(),
+        ])
     );
 }
 
@@ -3257,6 +3398,23 @@ fn test_status_rejects_unavailable_scope_commit_but_all_still_works() {
 }
 
 #[test]
+fn test_status_reports_missing_version_two_base_oid() {
+    let repo = setup_identity_only_review_branch();
+    let missing_base = "0000000000000000000000000000000000000000";
+    let endpoint = repo.rev_parse("HEAD");
+    repo.git(&[
+        "config",
+        "--local",
+        "branch.review-main-develop.cresca-scope",
+        &format!("2:{missing_base}:{endpoint}"),
+    ]);
+    assert_scope_error_and_all_available(
+        &repo,
+        &format!("saved range endpoint '{missing_base}' is unavailable"),
+    );
+}
+
+#[test]
 fn test_status_keeps_unbounded_review_tip_fixed_until_next_review() {
     let (repo, _) = setup_linear_range();
     assert!(repo
@@ -3333,6 +3491,82 @@ fn test_status_all_temporarily_reconstructs_after_target_and_source_rebase_witho
 }
 
 #[test]
+fn test_status_all_uses_latest_explicit_base_after_repeated_base_updates() {
+    let repo = TempGitRepo::new();
+    repo.write_file("deleted-from-target.txt", "initial target content\n");
+    repo.git(&["add", "deleted-from-target.txt"]);
+    repo.commit("Add initial target fixture");
+    repo.git(&["push", "origin", "main"]);
+    repo.create_branch("develop");
+    repo.write_file("approved.txt", "approved source content\n");
+    repo.git(&["add", "approved.txt"]);
+    repo.commit("Add approved source content");
+    repo.git(&["push", "-u", "origin", "develop"]);
+    repo.switch_branch("main");
+    assert!(repo
+        .run_cresca(&["review", "main", "develop"])
+        .status
+        .success());
+    repo.git(&["add", "approved.txt"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+
+    repo.switch_branch("main");
+    repo.git(&["rm", "deleted-from-target.txt"]);
+    repo.write_file("first-target-only.txt", "first target baseline\n");
+    repo.git(&["add", "first-target-only.txt"]);
+    repo.commit("First target base update");
+    repo.git(&["push", "origin", "main"]);
+    repo.git(&["checkout", "-B", "develop", "main"]);
+    repo.write_file("approved.txt", "approved source content\n");
+    repo.write_file("approved-after-first.txt", "approved after first update\n");
+    repo.git(&["add", "approved.txt", "approved-after-first.txt"]);
+    repo.commit("Rebase source after first target update");
+    repo.git(&["push", "--force", "origin", "develop"]);
+    repo.switch_branch("review-main-develop");
+    assert!(repo
+        .run_cresca(&["review", "main", "develop"])
+        .status
+        .success());
+    repo.git(&["add", "approved-after-first.txt"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+    assert!(repo.worktree_diff().is_empty());
+
+    repo.switch_branch("main");
+    repo.git(&["rm", "first-target-only.txt"]);
+    repo.write_file("second-target-only.txt", "second target baseline\n");
+    repo.git(&["add", "second-target-only.txt"]);
+    repo.commit("Second target base update");
+    repo.git(&["push", "origin", "main"]);
+    repo.git(&["checkout", "-B", "develop", "main"]);
+    repo.write_file("approved.txt", "approved source content\n");
+    repo.write_file("approved-after-first.txt", "approved after first update\n");
+    repo.write_file("later.txt", "later unreviewed content\n");
+    repo.git(&["add", "."]);
+    repo.commit("Rebase source after second target update");
+    repo.git(&["push", "--force", "origin", "develop"]);
+    repo.switch_branch("review-main-develop");
+    repo.git(&[
+        "config",
+        "--local",
+        "branch.review-main-develop.cresca-scope",
+        "malformed",
+    ]);
+
+    let before = repo.snapshot();
+    let all = run_status_stdout(&repo, &["status", "--all"]);
+    assert!(
+        all.contains("1 file(s), +1 insertion(s), -0 deletion(s)"),
+        "{all}"
+    );
+    assert!(all.contains("    - later.txt\n"), "{all}");
+    assert!(!all.contains("first-target-only.txt"), "{all}");
+    assert!(!all.contains("second-target-only.txt"), "{all}");
+    assert!(!all.contains("approved.txt"), "{all}");
+    assert!(!all.contains("approved-after-first.txt"), "{all}");
+    assert_eq!(repo.snapshot(), before);
+}
+
+#[test]
 fn test_status_all_fails_closed_for_unrelated_source_history_without_mutation() {
     let repo = TempGitRepo::new();
     repo.git(&["checkout", "--orphan", "develop"]);
@@ -3401,6 +3635,42 @@ fn test_status_all_fails_closed_for_multiple_merge_bases_without_mutation() {
     assert!(!output.status.success());
     assert!(
         String::from_utf8_lossy(&output.stderr).contains("Multiple merge bases"),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(repo.snapshot(), before);
+}
+
+#[test]
+fn test_status_all_fails_closed_for_ambiguous_explicit_base_correspondence() {
+    let (repo, _) = setup_linear_range();
+    assert!(repo
+        .run_cresca(&["review", "main", "develop"])
+        .status
+        .success());
+    repo.git(&["add", "-A"]);
+    assert!(repo.run_cresca(&["approve"]).status.success());
+    let previous = repo.rev_parse("HEAD");
+    let tree = repo.rev_parse("HEAD^{tree}");
+    let first_base = repo.rev_parse("origin/main");
+    let second_base = repo.rev_parse("origin/develop");
+    let message = format!(
+        "Ambiguous base fixture\n\nCresca-Review-Base: {first_base}\nCresca-Review-Base: {second_base}"
+    );
+    let ambiguous = repo.git_stdout(&["commit-tree", &tree, "-p", &previous, "-m", &message]);
+    repo.git(&[
+        "update-ref",
+        "refs/heads/review-main-develop",
+        &ambiguous,
+        &previous,
+    ]);
+    repo.git(&["reset", "--hard", &ambiguous]);
+    let before = repo.snapshot();
+
+    let output = repo.run_cresca(&["status", "--all"]);
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("ambiguous explicit base markers"),
         "{}",
         String::from_utf8_lossy(&output.stderr)
     );


### PR DESCRIPTION
Reviews now compare the requested source endpoint with its unique merge base against the target and reconstruct existing approvals from the saved version 1 scope (`1:<base>:<endpoint>`). When the target or source moves, only approvals with a safe correspondence survive; conflicting text, binary, mode, symlink, deletion, and ambiguous identical file or Gitlink renames return to the new base. `status` remains pinned to the saved endpoint.

`status --all` has been removed, and unsupported metadata shapes are not migrated. Review branches created with earlier unreleased scope shapes must be recreated. Reconstruction preserves the previous review as the sole parent, uses a plain commit message, and restores refs, metadata, index, and worktree state if an update fails.